### PR TITLE
Remove unnecessary EPD() in DataEditor.py, fix typo.

### DIFF
--- a/EUD Editor 3/Class/BulidData/WriteButtonData.vb
+++ b/EUD Editor 3/Class/BulidData/WriteButtonData.vb
@@ -28,8 +28,8 @@ Partial Public Class BuildData
                 Dim buttonCount As Integer = pjData.ExtraDat.ButtonData.GetButtonSet(newButtonIndex).ButtonS.Count
 
                 sb.AppendLine("    DoActions([")
-                sb.AppendLine("        SetMemoryEPD(EPD(0x" & Hex(Val("&H" & Hex(Tool.GetOffset("FG_BtnAddress"))) + 12 * Index) & "), SetTo, " & Address(newButtonIndex) & "),")
-                sb.AppendLine("        SetMemoryEPD(EPD(0x" & Hex(Val("&H" & Hex(Tool.GetOffset("FG_BtnNum"))) + 12 * Index) & "), SetTo, " & buttonCount & "),")
+                sb.AppendLine("        SetMemory(0x" & Hex(Val("&H" & Hex(Tool.GetOffset("FG_BtnAddress"))) + 12 * Index) & ", SetTo, " & Address(newButtonIndex) & "),")
+                sb.AppendLine("        SetMemory(0x" & Hex(Val("&H" & Hex(Tool.GetOffset("FG_BtnNum"))) + 12 * Index) & ", SetTo, " & buttonCount & "),")
                 sb.AppendLine("    ])")
             ElseIf Not IsNumeric(Address(Index)) Then
                 '원본인데 데이터가 변형되었다면?
@@ -37,8 +37,8 @@ Partial Public Class BuildData
                 Dim buttonCount As Integer = pjData.ExtraDat.ButtonData.GetButtonSet(Index).ButtonS.Count
 
                 sb.AppendLine("    DoActions([")
-                sb.AppendLine("        SetMemoryEPD(EPD(0x" & Hex(Val("&H" & Hex(Tool.GetOffset("FG_BtnAddress"))) + 12 * Index) & "), SetTo, " & Address(newButtonIndex) & "),")
-                sb.AppendLine("        SetMemoryEPD(EPD(0x" & Hex(Val("&H" & Hex(Tool.GetOffset("FG_BtnNum"))) + 12 * Index) & "), SetTo, " & buttonCount & "),")
+                sb.AppendLine("        SetMemory(0x" & Hex(Val("&H" & Hex(Tool.GetOffset("FG_BtnAddress"))) + 12 * Index) & ", SetTo, " & Address(newButtonIndex) & "),")
+                sb.AppendLine("        SetMemory(0x" & Hex(Val("&H" & Hex(Tool.GetOffset("FG_BtnNum"))) + 12 * Index) & ", SetTo, " & buttonCount & "),")
                 sb.AppendLine("    ])")
             End If
         Next

--- a/EUD Editor 3/Class/BulidData/WriteDatFile.vb
+++ b/EUD Editor 3/Class/BulidData/WriteDatFile.vb
@@ -7,75 +7,77 @@ Partial Public Class BuildData
 
         sb.AppendLine("from eudplib import *")
         sb.AppendLine("")
+        sb.AppendLine("")
         sb.AppendLine("def onPluginStart():")
-        sb.AppendLine("    pass # NULL에러 방지용")
-        sb.AppendLine("    DoActions([ # 기본 Dat파일 액션")
+        sb.AppendLine("    DoActions([  # Basic DatFile Actions")
 
         '기본 Dat파일 저장
         For DatFile = 0 To SCDatFiles.DatFiles.orders - 1
             For Pindex = 0 To pjData.Dat.DatFileList(DatFile).ParamaterList.Count - 1
                 Dim ParamaterData As SCDatFiles.CDatFile.CParamater = pjData.Dat.DatFileList(DatFile).ParamaterList(Pindex)
 
-                If ParamaterData.GetInfo(SCDatFiles.EParamInfo.IsEnabled) Then
-                    Dim Parameter As String = ParamaterData.GetParamname
-                    Dim Offset As UInteger = Tool.GetOffset(DatFile, Parameter)
-                    Dim Size As Byte = ParamaterData.GetInfo(SCDatFiles.EParamInfo.Size)
-                    Dim Length As Byte = Size * ParamaterData.GetInfo(SCDatFiles.EParamInfo.VarArray)
-
-
-                    For ObjectID = 0 To ParamaterData.GetValueCount - 1
-                        If ParamaterData.PureData(ObjectID).Enabled And Not ParamaterData.PureData(ObjectID).IsDefault Then
-                            Dim OldValue As Long
-                            Dim NewValue As Long = ParamaterData.PureData(ObjectID).Data
-                            Dim CurrentValue As Long
-                            Dim CalOffset As UInteger = Offset + ObjectID * Length
-                            Dim ByteShift As Byte = CalOffset Mod 4
-                            Dim RealValue As Long
-                            Dim RealOffset As UInteger = CalOffset - CalOffset Mod 4
-
-
-                            If pjData.MapData.DatFile.GetDatFile(DatFile).GetParamValue(Parameter, ObjectID).IsDefault Then '맵 데이터가 없을 경우
-                                OldValue = scData.DefaultDat.GetDatFile(DatFile).ParamaterList(Pindex).PureData(ObjectID).Data
-                            Else
-                                OldValue = pjData.MapData.DatFile.GetDatFile(DatFile).ParamaterList(Pindex).PureData(ObjectID).Data
-                            End If
-
-                            CurrentValue = NewValue - OldValue
-                            RealValue = CurrentValue * Math.Pow(256, ByteShift)
-
-                            sb.Append("        SetMemoryEPD(EPD(0x" & Hex(RealOffset).ToUpper & "),Add ," & RealValue & "),")
-
-
-                            'Select Case Size
-                            '    Case 4
-                            '        sb.Append("    f_dwwrite_epd(EPD(0x" & Hex(Offset + ObjectID * Length).ToUpper & ")," & ParamaterData.PureData(ObjectID).Data & ")")
-                            '    Case 2
-                            '        sb.Append("    f_wwrite_epd(EPD(0x" & Hex(Offset + ObjectID * Length).ToUpper & ")," & ParamaterData.PureData(ObjectID).Data & ", " & (Offset + ObjectID * Length) Mod 4 & ")")
-                            '    Case 1
-                            '        sb.Append("    f_bwrite_epd(EPD(0x" & Hex(Offset + ObjectID * Length).ToUpper & ")," & ParamaterData.PureData(ObjectID).Data & ", " & (Offset + ObjectID * Length) Mod 4 & ")")
-                            'End Select
-
-
-                            sb.AppendLine("# " & Datfilesname(DatFile) & ":" & Parameter & "  index:" & ObjectID & "    from " & OldValue & " To " & NewValue)
-                        End If
-                    Next
-                    'pjData.Dat.Data(DatFile, Parameter, ObjectID)
+                If Not ParamaterData.GetInfo(SCDatFiles.EParamInfo.IsEnabled) Then
+                    Continue For
                 End If
+                Dim Parameter As String = ParamaterData.GetParamname
+                Dim Offset As UInteger = Tool.GetOffset(DatFile, Parameter)
+                Dim Size As Byte = ParamaterData.GetInfo(SCDatFiles.EParamInfo.Size)
+                Dim Length As Byte = Size * ParamaterData.GetInfo(SCDatFiles.EParamInfo.VarArray)
+
+
+                For ObjectID = 0 To ParamaterData.GetValueCount - 1
+                    If (Not ParamaterData.PureData(ObjectID).Enabled) Or _
+                        ParamaterData.PureData(ObjectID).IsDefault Then
+                        Continue For
+                    End If
+                    Dim OldValue As Long
+                    Dim NewValue As Long = ParamaterData.PureData(ObjectID).Data
+                    Dim CurrentValue As Long
+                    Dim CalOffset As UInteger = Offset + ObjectID * Length
+                    Dim ByteShift As Byte = CalOffset Mod 4
+                    Dim RealValue As Long
+                    Dim RealOffset As UInteger = CalOffset - CalOffset Mod 4
+
+
+                    If pjData.MapData.DatFile.GetDatFile(DatFile).GetParamValue(Parameter, ObjectID).IsDefault Then '맵 데이터가 없을 경우
+                        OldValue = scData.DefaultDat.GetDatFile(DatFile).ParamaterList(Pindex).PureData(ObjectID).Data
+                    Else
+                        OldValue = pjData.MapData.DatFile.GetDatFile(DatFile).ParamaterList(Pindex).PureData(ObjectID).Data
+                    End If
+
+                    CurrentValue = NewValue - OldValue
+                    RealValue = CurrentValue * Math.Pow(256, ByteShift)
+
+                    sb.Append("        SetMemory(0x" & Hex(RealOffset).ToUpper & ", Add, " & RealValue & "),")
+
+
+                    'Select Case Size
+                    '    Case 4
+                    '        sb.Append("    f_dwwrite_epd(EPD(0x" & Hex(Offset + ObjectID * Length).ToUpper & ")," & ParamaterData.PureData(ObjectID).Data & ")")
+                    '    Case 2
+                    '        sb.Append("    f_wwrite_epd(EPD(0x" & Hex(Offset + ObjectID * Length).ToUpper & ")," & ParamaterData.PureData(ObjectID).Data & ", " & (Offset + ObjectID * Length) Mod 4 & ")")
+                    '    Case 1
+                    '        sb.Append("    f_bwrite_epd(EPD(0x" & Hex(Offset + ObjectID * Length).ToUpper & ")," & ParamaterData.PureData(ObjectID).Data & ", " & (Offset + ObjectID * Length) Mod 4 & ")")
+                    'End Select
+
+
+                    sb.AppendLine("# " & Datfilesname(DatFile) & ":" & Parameter & "  index:" & ObjectID & "    from " & OldValue & " To " & NewValue)
+                Next
+                'pjData.Dat.Data(DatFile, Parameter, ObjectID)
             Next
         Next
 
         sb.AppendLine("    ])")
-        sb.AppendLine("    ")
         sb.AppendLine("")
-
 
 
         '[EUDEditor.py]
 
-        '[TriggerEditor.eps]
-
         '[dataDumper]
         'D\:\source\repos\EUDEditor\EUD Editor\bin\x86\Release\Data\temp\RequireData : 0x58D740, copy
+
+        '[TriggerEditor.eps]
+
 
         Dim filestreama As New FileStream(DatpyFilePath, FileMode.Create)
         Dim strWriter As New StreamWriter(filestreama, Encoding.UTF8)
@@ -92,18 +94,18 @@ Partial Public Class BuildData
 
         sb.AppendLine("from eudplib import *")
         sb.AppendLine("")
+        sb.AppendLine("")
         sb.AppendLine("def onPluginStart():")
-        sb.AppendLine("    pass # NULL에러 방지용")
 
         '와이어프레임, 버튼셋, 요구사항, 상태플래그
         WriteWireFrame(sb)
         WriteStatusInfor(sb)
         WriteButtonSet(sb)
         sb.AppendLine("    DoActions([ # RequreData 포인터 작성")
-        sb.AppendLine("       SetMemory(0x" & Hex(Tool.GetOffset("Vanilla")) & ", SetTo, 0x" & Hex(Tool.GetOffset("FG_ReqUnit")) & ")")
+        sb.AppendLine("        SetMemory(0x" & Hex(Tool.GetOffset("Vanilla")) & ", SetTo, 0x" & Hex(Tool.GetOffset("FG_ReqUnit")) & ")")
         sb.AppendLine("    ])")
 
-        sb.AppendLine("    ")
+        sb.AppendLine("")
         sb.AppendLine("")
 
 
@@ -129,9 +131,6 @@ Partial Public Class BuildData
     End Sub
 
 
-
-
-
     Private Sub WriteStatusInfor(sb As StringBuilder)
         sb.AppendLine("    DoActions([ # 스테이터스인포메이션")
         For i = 0 To SCUnitCount - 1
@@ -141,7 +140,7 @@ Partial Public Class BuildData
                 Dim _offsetNum As Long = Tool.GetOffset("FG_Status") + 12 * i
                 Dim _offset As String = Hex(_offsetNum)
 
-                sb.AppendLine("       SetMemory(" & "0x" & _offset & ", SetTo, " & _lastvalue & "),")
+                sb.AppendLine("        SetMemory(0x" & _offset & ", SetTo, " & _lastvalue & "),")
             End If
             If Not pjData.ExtraDat.DefaultStatusFunction2(i) Then
                 Dim _lastvalue As Long = scData.statusFnVal2(pjData.ExtraDat.StatusFunction2(i))
@@ -149,11 +148,13 @@ Partial Public Class BuildData
                 Dim _offsetNum As Long = Tool.GetOffset("FG_Display") + 12 * i
                 Dim _offset As String = Hex(_offsetNum)
 
-                sb.AppendLine("       SetMemory(" & "0x" & _offset & ", SetTo, " & _lastvalue & "),")
+                sb.AppendLine("        SetMemory(0x" & _offset & ", SetTo, " & _lastvalue & "),")
             End If
         Next
         sb.AppendLine("    ])")
     End Sub
+
+
     Private Sub WriteWireFrame(sb As StringBuilder)
         '바뀐게 있는지 체크.
         Dim checkflag As Boolean = False
@@ -161,23 +162,18 @@ Partial Public Class BuildData
             If Not pjData.ExtraDat.DefaultWireFrame(i) Then
                 checkflag = True
                 Exit For
+            ElseIf Not pjData.ExtraDat.DefaultGrpFrame(i) Then
+                checkflag = True
+                Exit For
             End If
         Next
         If checkflag = False Then
-            For i = 0 To SCUnitCount - 1
-                If Not pjData.ExtraDat.DefaultGrpFrame(i) Then
+            For i = 0 To SCMenCount - 1
+                If Not pjData.ExtraDat.DefaultTranFrame(i) Then
                     checkflag = True
                     Exit For
                 End If
             Next
-            If checkflag = False Then
-                For i = 0 To SCMenCount - 1
-                    If Not pjData.ExtraDat.DefaultTranFrame(i) Then
-                        checkflag = True
-                        Exit For
-                    End If
-                Next
-            End If
         End If
 
 
@@ -213,14 +209,14 @@ Partial Public Class BuildData
             Next
 
 
-            sb.AppendLine("    WireOffset = f_dwread_epd(EPD(0x" & Hex(Tool.GetOffset("wirefram.grp")) & "))")
+            sb.AppendLine("    WireOffset = f_epdread_epd(EPD(0x" & Hex(Tool.GetOffset("wirefram.grp")) & "))")
             sb.AppendLine("    DoActions([")
             For i = 0 To grpframecount - 1
                 If Not pjData.ExtraDat.DefaultWireFrame(i) Then
                     memStream.Position = 4 + 8 * i
-                    sb.AppendLine("    SetMemoryEPD(EPD(WireOffset + " & 4 + 8 * i & "), SetTo, " & binaryReader.ReadUInt32 & "),")
-                    sb.AppendLine("    SetMemoryEPD(EPD(WireOffset + " & 8 + 8 * i & "), SetTo, " & binaryReader.ReadUInt32 & "),")
-                    sb.AppendLine("    SetMemoryEPD(EPD(WireOffset + " & 12 + 8 * i & "), SetTo, " & binaryReader.ReadUInt32 & "),")
+                    sb.AppendLine("        SetMemoryEPD(WireOffset + " & 1 + 2 * i & ", SetTo, " & binaryReader.ReadUInt32 & "),")
+                    sb.AppendLine("        SetMemoryEPD(WireOffset + " & 2 + 2 * i & ", SetTo, " & binaryReader.ReadUInt32 & "),")
+                    sb.AppendLine("        SetMemoryEPD(WireOffset + " & 3 + 2 * i & ", SetTo, " & binaryReader.ReadUInt32 & "),")
                 End If
             Next
             sb.AppendLine("    ])")
@@ -253,14 +249,14 @@ Partial Public Class BuildData
             Next
 
 
-            sb.AppendLine("    GrpOffset = f_dwread_epd(EPD(0x" & Hex(Tool.GetOffset("grpwire.grp")) & "))")
+            sb.AppendLine("    GrpOffset = f_epdread_epd(EPD(0x" & Hex(Tool.GetOffset("grpwire.grp")) & "))")
             sb.AppendLine("    DoActions([")
             For i = 0 To grpframecount - 1
                 If Not pjData.ExtraDat.DefaultGrpFrame(i) Then
                     memStream.Position = 4 + 8 * i
-                    sb.AppendLine("    SetMemoryEPD(EPD(GrpOffset + " & 4 + 8 * i & "), SetTo, " & binaryReader.ReadUInt32 & "),")
-                    sb.AppendLine("    SetMemoryEPD(EPD(GrpOffset + " & 8 + 8 * i & "), SetTo, " & binaryReader.ReadUInt32 & "),")
-                    sb.AppendLine("    SetMemoryEPD(EPD(GrpOffset + " & 12 + 8 * i & "), SetTo, " & binaryReader.ReadUInt32 & "),")
+                    sb.AppendLine("        SetMemoryEPD(GrpOffset + " & 1 + 2 * i & "), SetTo, " & binaryReader.ReadUInt32 & "),")
+                    sb.AppendLine("        SetMemoryEPD(GrpOffset + " & 2 + 2 * i & "), SetTo, " & binaryReader.ReadUInt32 & "),")
+                    sb.AppendLine("        SetMemoryEPD(GrpOffset + " & 3 + 2 * i & "), SetTo, " & binaryReader.ReadUInt32 & "),")
                 End If
             Next
             sb.AppendLine("    ])")
@@ -293,14 +289,14 @@ Partial Public Class BuildData
             Next
 
 
-            sb.AppendLine("    tranOffset = f_dwread_epd(EPD(0x" & Hex(Tool.GetOffset("tranwire.grp")) & "))")
+            sb.AppendLine("    tranOffset = f_epdread_epd(EPD(0x" & Hex(Tool.GetOffset("tranwire.grp")) & "))")
             sb.AppendLine("    DoActions([")
             For i = 0 To grpframecount - 1
                 If Not pjData.ExtraDat.DefaultTranFrame(i) Then
                     memStream.Position = 4 + 8 * i
-                    sb.AppendLine("    SetMemoryEPD(EPD(tranOffset + " & 4 + 8 * i & "), SetTo, " & binaryReader.ReadUInt32 & "),")
-                    sb.AppendLine("    SetMemoryEPD(EPD(tranOffset + " & 8 + 8 * i & "), SetTo, " & binaryReader.ReadUInt32 & "),")
-                    sb.AppendLine("    SetMemoryEPD(EPD(tranOffset + " & 12 + 8 * i & "), SetTo, " & binaryReader.ReadUInt32 & "),")
+                    sb.AppendLine("        SetMemoryEPD(tranOffset + " & 1 + 2 * i & ", SetTo, " & binaryReader.ReadUInt32 & "),")
+                    sb.AppendLine("        SetMemoryEPD(tranOffset + " & 2 + 2 * i & ", SetTo, " & binaryReader.ReadUInt32 & "),")
+                    sb.AppendLine("        SetMemoryEPD(tranOffset + " & 3 + 2 * i & ", SetTo, " & binaryReader.ReadUInt32 & "),")
                 End If
             Next
             sb.AppendLine("    ])")

--- a/EUD Editor 3/Class/BulidData/WriteReqFile.vb
+++ b/EUD Editor 3/Class/BulidData/WriteReqFile.vb
@@ -92,8 +92,8 @@ Partial Public Class BuildData
                     value += pos * 65536
                 End If
                 If k Mod 2 = 1 Then
-                    sb.AppendLine("       SetMemoryEPD(EPD(" & "0x" & pointer & " + " & (k * 2) - 2 & "), SetTo, " & value & "),")
-                    'returntext.AppendLine("       # " & value Mod 256 & " " & value \ 65536)
+                    sb.AppendLine("        SetMemory(0x" & pointer & " + " & (k * 2) - 2 & ", SetTo, " & value & "),")
+                    'returntext.AppendLine("        # " & value Mod 256 & " " & value \ 65536)
                 End If
 
             Next

--- a/EUD Editor 3/Class/BulidData/WriteedsFile.vb
+++ b/EUD Editor 3/Class/BulidData/WriteedsFile.vb
@@ -16,9 +16,6 @@ Partial Public Class BuildData
             sb.AppendLine("")
         End If
 
-        '[TriggerEditor.eps]
-
-
         sb.AppendLine("[dataDumper]")
         If pjData.UseCustomtbl Then
             'tbl 파일 쓰기
@@ -32,6 +29,10 @@ Partial Public Class BuildData
         'D\:\source\repos\EUDEditor\EUD Editor\bin\x86\Release\Data\temp\stat_txt.tbl : 0x6D5A30, copy"
         '[dataDumper]
         'D\:\source\repos\EUDEditor\EUD Editor\bin\x86\Release\Data\temp\RequireData : 0x58D740, copy
+
+
+        '[TriggerEditor.eps]
+
 
         Dim filestreama As New FileStream(EdsFilePath, FileMode.Create)
         Dim strWriter As New StreamWriter(filestreama)

--- a/EUD Editor 3/Language/ko-KR.xaml
+++ b/EUD Editor 3/Language/ko-KR.xaml
@@ -6,7 +6,7 @@
 
 
     <sys:String x:Key="DataLoading">실행을 위해 데이터를 불러오는 중...</sys:String>
-    <sys:String x:Key="RegistryConnect">확장자가 연결 되어 있지 않습니다. 연결 하시겠습니까?</sys:String>
+    <sys:String x:Key="RegistryConnect">확장자가 연결되어 있지 않습니다. 연결하시겠습니까?</sys:String>
 
 
     <sys:String x:Key="Setting">설정</sys:String>
@@ -28,7 +28,7 @@
 
 
 
-    <sys:String x:Key="TBLChange">사용저 정의 tbl사용</sys:String>
+    <sys:String x:Key="TBLChange">사용자 정의 tbl사용</sys:String>
     <sys:String x:Key="chkDataFirst">chk데이터 우선</sys:String>
     <sys:String x:Key="AutoCompile">자동 빌드</sys:String>
     

--- a/EUD Editor 3/Language/us-EN.xaml
+++ b/EUD Editor 3/Language/us-EN.xaml
@@ -8,7 +8,7 @@
     <sys:String x:Key="OpenMap">OpenMap</sys:String>
     <sys:String x:Key="SaveMap">SaveMap</sys:String>
     <sys:String x:Key="Find">Find</sys:String>
-    <sys:String x:Key="TBLChange">TBLChange</sys:String>
+    <sys:String x:Key="TBLChange">Use custom TBL</sys:String>
     <sys:String x:Key="chkDataFirst">chkDataFirst</sys:String>
     <sys:String x:Key="AutoCompile">AutoCompile</sys:String>
     <sys:String x:Key="Project Setting">Project Setting</sys:String>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # EUD-Editor-3
-StarCraft:Reamster UMS Make Tool
+StarCraft: Remastered UMS Make Tool
 
 
 


### PR DESCRIPTION
- There is no need to use `MemoryEPD(EPD(address), modtype, value)` if address is constant expression.
- `WireOffset`, `GrpOffset`, and `TransOffset` are `EUDVariable`, since they are return values of eud function. `f_epdread_epd` is better than `f_dwread_epd` and using `EPD(EUDVariable)` in every `SetMemoryEPD`.
- `[dataDumper]` should run before `[TriggerEditor.eps]`, otherwise accessing `stat_txt.tbl` in `onPluginStart` of `TriggerEditor` results in invalid value.
- Fix indentation.
- Fix typo.