### PR TITLE
Use host encoding for STR instead of CP949

### DIFF
--- a/EUD Editor 3/Class/Data/MapData.vb
+++ b/EUD Editor 3/Class/Data/MapData.vb
@@ -624,7 +624,7 @@ Public Class MapData
 
                     mem.Position = BasePos + StartPos
 
-                    Strings.Add(System.Text.Encoding.GetEncoding(949).GetString(binary.ReadBytes(Bytecount - 1)))
+                    Strings.Add(System.Text.Encoding.GetEncoding(0).GetString(binary.ReadBytes(Bytecount - 1)))
 
                     lastPos += 2
                 Next


### PR DESCRIPTION
한국 사용자는 기본 인코딩 = CP949라서 상관없지만,
외국인 사용자가 SCMDraft2로 비-아스키 문자를 맵 스트링에 넣으면 외국 ANSI 인코딩 != CP949라서 스트링 제대로 못 읽어옵니다.

https://docs.microsoft.com/ko-kr/dotnet/api/system.text.encoding.getencoding?view=netcore-3.1#System_Text_Encoding_GetEncoding_System_Int32_
Encoding.GetEncoding(0) 넣으면 기본 인코딩을 사용하니까 위와 같은 문제가 방지됩니다.