### PR TITLE
TechOffset 오타 수정

### DIFF
--- a/EUD Editor 3/Data/Lua/TriggerEditor/Tech.lua
+++ b/EUD Editor 3/Data/Lua/TriggerEditor/Tech.lua
@@ -194,7 +194,7 @@ function TechOffset(Tech, Player) --테크/Tech,TrgPlayer/[Player]의 [Tech]의 
 		offset = offset + Player * Size + Tech
 		return offset
 	else
-		offset = string.format("0x%X + %s * %s + %s", offset, Player, Tech)
+		offset = string.format("0x%X + %s * %s + %s", offset, Player, Size, Tech)
 		return offset
 	end
 end


### PR DESCRIPTION
업그레이드 플레이어가 상수가 아닐 때 계산에서 Size가 빠져있음.
 ```lua
offset = string.format("0x%X + %s * %s + %s", offset, Player, Tech)
```