### PR TITLE
Fixed `BuildSCV`, `BuildDrone` and `SetPColor`

### DIFF
--- a/EUD Editor 3/Data/TriggerEditor/TETools.eps
+++ b/EUD Editor 3/Data/TriggerEditor/TETools.eps
@@ -108,7 +108,7 @@ function BuildProbe(unitPTR, loc: TrgLocation, building: TrgUnit) {
 ***/
 function BuildDroneEPD(epd, loc: TrgLocation, building: TrgUnit) {
     SetMemoryXEPD(epd + 0x98 / 4, SetTo, building, 0xFFFF);
-    __LocOrderBase(epd, 25 << 8, loc, building);
+    __LocOrderBase(epd, 25 << 8, loc);
 }
 
 /***
@@ -147,7 +147,7 @@ function BuildDrone(unitPTR, loc: TrgLocation, building: TrgUnit) {
 ***/
 function BuildSCVEPD(epd, loc: TrgLocation, building: TrgUnit) {
     SetMemoryXEPD(epd + 0x98 / 4, SetTo, building, 0xFFFF);
-    __LocOrderBase(epd, 30 << 8, loc, building);
+    __LocOrderBase(epd, 30 << 8, loc);
 }
 
 /***

--- a/EUD Editor 3/Data/TriggerEditor/TETools.eps
+++ b/EUD Editor 3/Data/TriggerEditor/TETools.eps
@@ -321,7 +321,7 @@ function RotateLocation(targetLoc: TrgLocation, originLoc: TrgLocation, angle) {
 ***/
 function RemoveStatusFlagsEPD(epd, flags) {
     epd += 0xDC / 4;
-    DoActions(SetMemoryXEPD(epd, SetTo, 0, flags));
+    SetMemoryXEPD(epd, SetTo, 0, flags);
 }
 
 /***
@@ -358,7 +358,7 @@ function SetPColor(Player: TrgPlayer, Color) {
     Player -= 0x581DD6;
     Player += Player;
     Player += EPD(0x581D76);
-    bwrite_epd(Player, 0, Color)
+    bwrite_epd(Player, 2, Color)
 }
 
 function __SpawnBase(epd, unit: TrgUnit, newUnit: TrgUnit) {
@@ -468,14 +468,20 @@ function MorphLarvaEPD(epd, newUnit: TrgUnit) {
 ***/
 function TrainUnitEPD(epd, newUnit: TrgUnit) {
     const nU_and_lsh16 = newUnit * 65537;
-    epd += 0x98/4;
-    SetMemoryEPD(epd, SetTo, nU_and_lsh16);
-    epd += 1;
-    SetMemoryEPD(epd, SetTo, nU_and_lsh16);
-    epd += 1;
-    SetMemoryXEPD(epd, SetTo, newUnit, 0xFFFF);
-    epd += 1;
-    SetMemoryXEPD(epd, SetTo, 38 << 16, 0xFF0000);
+    VProc(epd, list(
+        epd.AddNumber(0x98/4),
+        epd.SetDest(EPD(0x6509B0)),
+    ));
+    DoActions(
+        SetDeaths(CurrentPlayer, SetTo, nU_and_lsh16, 0),
+        SetMemory(0x6509B0, Add, 1),
+        SetDeaths(CurrentPlayer, SetTo, nU_and_lsh16, 0),
+        SetMemory(0x6509B0, Add, 1),
+        SetDeathsX(CurrentPlayer, SetTo, newUnit, 0, 0xFFFF),
+        SetMemory(0x6509B0, Add, 1),
+        SetDeathsX(CurrentPlayer, SetTo, 38 << 16, 0, 0xFF0000),
+    );
+    setcurpl2cpcache();
 }
 
 /***
@@ -826,7 +832,7 @@ function CheckNoneTargetSkillEPD(
         if (range > LocationDistance(unitLoc, targetLoc)) {
             MoveLocation(targetLoc, 227, AllPlayers, targetLoc);
             unitEPD += -((0x58 - 0x4C)/4);
-        	SetMemoryXEPD(unitEPD, SetTo, 0x100, 0xFF00);
+            SetMemoryXEPD(unitEPD, SetTo, 0x100, 0xFF00);
             unitEPD += -((0x4D - 0x10)/4);
             SetMemoryEPD(unitEPD, SetTo, x + y * 65536);
             return True;


### PR DESCRIPTION
- `BuildSCV`, `BuildDrone`: 헬퍼 함수 `__LocOrderBase(epd, order_lsh8, loc: TrgLocation)`를 `__LocOrderBase(epd, 30 << 8, loc, building);` 같이 호출하는 버그 수정.
- `SetPColor`: 플레이어 색 오프셋 `0x581D76` 이니까 `bwrite_epd(Player, 0, Color)` 에서 `bwrite_epd(Player, 2, Color)` 로 수정.