### PR TITLE
TETools: Fix RotateLocation

### DIFF
--- a/EUD Editor 3/Data/TriggerEditor/TETools.eps
+++ b/EUD Editor 3/Data/TriggerEditor/TETools.eps
@@ -296,8 +296,9 @@ function RotateLocation(targetLoc: TrgLocation, originLoc: TrgLocation, angle) {
     const ox, oy = (ox1+ox2), (oy1+oy2);
     const dx, dy = tx-ox, ty-oy;
     const theta = atan2(dy, dx);
-    const x, y = lengthdir(sqrt(dx*dx+dy*dy)/2, theta+angle);
-    const rx, ry = x-dx, y-dy;
+    const dx2, dy2 = dx/2, dy/2;
+    const x, y = lengthdir(sqrt(dx2*dx2+dy2*dy2)+1, theta+angle);
+    const rx, ry = x-dx2, y-dy2;
     dwadd_epd(target, ry);
     DoActions(target.AddNumber(-1));
     dwadd_epd(target, rx);


### PR DESCRIPTION
- dx, dy에 2가 곱해져있는데 그냥 계산해서 생긴 버그 수정
- lengthdir 계산으로 손실되는 로케이션 사이 거리 보정
- 관련 카페글: https://cafe.naver.com/edac/130725

![test](https://github.com/Buizz/EUD-Editor-3/assets/16814706/39aa3c4e-4737-43aa-9f4c-9b709a5de268)
```js
TETools.RotateLocation("3'o", "center", 10);
```
