### PR TITLE
Bug Fixed & Added SCR::fmt

### DIFF
--- a/EUD Editor 3/Class/BulidData/WriteSCAData.vb
+++ b/EUD Editor 3/Class/BulidData/WriteSCAData.vb
@@ -291,9 +291,10 @@ Partial Public Class BuildData
         sb.AppendLine("    ));")
         sb.AppendLine("}")
         sb.AppendLine("")
-        sb.AppendLine("function Exec() {")
-        sb.AppendLine("    Init();")
-        sb.AppendLine("}")
+        ' Unnecessary Exec func!
+        ' sb.AppendLine("function Exec() {")
+        ' sb.AppendLine("    Init();")
+        ' sb.AppendLine("}")
         sb.AppendLine("")
 
         sb.AppendLine("function ResetValue(tagNum, index) {")

--- a/EUD Editor 3/Data/Lua/TriggerEditor/SCA.lua
+++ b/EUD Editor 3/Data/Lua/TriggerEditor/SCA.lua
@@ -31,7 +31,7 @@ function SCAScriptRunFunc(ScriptName, ReturnIndex, ...)
 		argcount = argcount + 1
 	end
 
-	echo("scalua.scaExecScript(".. ParseSCAScript(ScriptName) .. ", " .. ReturnIndex .. ", " .. argcount .. ", EPD(SCAArgArray))") --배열의 EPD를 넘겨준다.
+	echo("scalua.scaExecScript(".. ParseSCAScript(ScriptName) .. ", " .. ReturnIndex .. ", " .. argcount .. ", SCAArgArray)") --배열의 EPD를 넘겨준다.
 end
 
 

--- a/EUD Editor 3/Data/TriggerEditor/SCAScriptReturn.eps
+++ b/EUD Editor 3/Data/TriggerEditor/SCAScriptReturn.eps
@@ -15,44 +15,34 @@ const mersenne_gte = py_eval("f_mersenne_gte");
 const ArrayobjectN = 5000;
 const Arraysize = 1000;
 const ArrayMask = mersenne_gte(Arraysize);
-const Arraybuffer = EUDVArray(ArrayobjectN)(py_eval("lambda x, y: [EUDArray(x) for _ in range(y)]")(Arraysize, ArrayobjectN));
+const Arraybuffer = EUDVArray(ArrayobjectN, EUDArray)(py_eval("lambda x, y: [EUDArray(x) for _ in range(y)]")(Arraysize, ArrayobjectN));
 var Arrayremaining = ArrayobjectN;
-function ArrayAlloc() {
+function ArrayAlloc(): EUDArray {
     Arrayremaining -= 1;
     return Arraybuffer[Arrayremaining];
 }
-function ArrayFree(num) {
-    Arrayremaining += num;
+function ArrayFree(arrEPD) {
+    Arraybuffer[Arrayremaining] = arrEPD;
+    Arrayremaining += 1;
 }
 
 const MiniArrayobjectN = 100;
 const MiniArraysize = 10;
 const MiniArrayMask = mersenne_gte(MiniArraysize);
-const MiniArraybuffer = EUDVArray(MiniArrayobjectN)(py_eval("lambda x, y: [EUDArray(x) for _ in range(y)]")(MiniArraysize, MiniArrayobjectN));
+const MiniArraybuffer = EUDVArray(MiniArrayobjectN, EUDArray)(py_eval("lambda x, y: [EUDArray(x) for _ in range(y)]")(MiniArraysize, MiniArrayobjectN));
 var MiniArrayremaining  = MiniArrayobjectN;
-function MiniArrayAlloc() {
+function MiniArrayAlloc(): EUDArray {
     MiniArrayremaining -= 1;
     return MiniArraybuffer[MiniArrayremaining];
 }
 
-function MiniArrayFree(num) {
-    MiniArrayremaining += num;
-}
-
-const StrobjectN = 100;
-const Strsize = 1000;
-const Strbuffer = (StringBuffer * StrobjectN)(py_eval("lambda x, y: [StringBuffer(x) for _ in range(y)]")(Strsize, StrobjectN));
-var Strremaining = StrobjectN;
-function StrAlloc(): StringBuffer {
-    Strremaining -= 1;
-    return Strbuffer[Strremaining];
-}
-function StrFree() {
-    Strremaining += 1;
+function MiniArrayFree(arrEPD) {
+    MiniArraybuffer[MiniArrayremaining] = arrEPD;
+    MiniArrayremaining += 1;
 }
 
 object SCAReturnString {
-    var values;
+    var values: EUDArray;
     var length;
 
     function constructor(length) {
@@ -64,13 +54,13 @@ object SCAReturnString {
         foreach(i: EUDLoopRange(this.length)) {
             dwwrite_epd(this.values + i, 0); // 할당된 값을 0으로 바꾼다.
         }
-        ArrayFree(1);
+        ArrayFree(this.values);
     }
 };
 
 object SCAReturnArray {
-    var values;
-    var types;
+    var values: EUDArray;
+    var types: EUDArray;
     var length;
 
     function constructor(length) {
@@ -87,7 +77,8 @@ object SCAReturnArray {
             }
             DoActions(SetMemoryEPD(values, SetTo, 0), SetMemoryEPD(types, SetTo, 0));  // 할당된 값을 0으로 바꾼다.
         }
-        ArrayFree(2);
+        ArrayFree(this.values);
+        ArrayFree(this.types);
     }
 };
 
@@ -95,9 +86,8 @@ object SCAReturn {
     //리턴을 여러개 받을 수 있음.
     //리턴을 받으면 값 삭제.
     
-    var values;
-    var types;
-    var strBuffer: StringBuffer;
+    var values: EUDArray;
+    var types: EUDArray;
     var returnindex;
     var returncount;
     var lastepd;
@@ -105,7 +95,6 @@ object SCAReturn {
     function constructor(epd) {
         this.values = MiniArrayAlloc();
         this.types = MiniArrayAlloc();
-        this.strBuffer = StrAlloc();
         const AdvanceEPD = function() {
             SetVariables(epd, 1, Add);
             Trigger(epd.AtLeast(scf.FuncLength), epd.SetNumber(0));
@@ -120,19 +109,14 @@ object SCAReturn {
         this.returncount = maskread_epd(scf.FuncReturnTableEPD + epd, MiniArrayMask); // 리턴 길이, 최대 10 (0 ~ 15)
         AdvanceEPD();
 
-        this.strBuffer.insert(0, "[");
         foreach(i: EUDLoopRange(this.returncount)){
             const values, types = this.values + i, this.types + i;
-            if (i > 0) {
-                this.strBuffer.append(", ");
-            }
             epdswitch(scf.FuncReturnTableEPD + epd, mersenne_gte(3)){ // 변수 종류, 최대 3
                 case 1: { //Number = 1
                     AdvanceEPD();
 
-                    const temp = dwread_epd(scf.FuncReturnTableEPD + epd);
-                    DoActions(SetMemoryEPD(values, SetTo, temp), SetMemoryEPD(types, SetTo, 1));
-                    this.strBuffer.appendf("{}", temp);
+                    repmovsd_epd(values, scf.FuncReturnTableEPD + epd, 1); // 값을 (4 * 1)bytes 만큼 복사한다.
+                    SetMemoryEPD(types, SetTo, 1);
                     AdvanceEPD();
                     break;
                 }
@@ -141,14 +125,13 @@ object SCAReturn {
                     const length = maskread_epd(scf.FuncReturnTableEPD + epd, ArrayMask); // 문자열 길이, 최대 1000 (0 ~ 1023)
                     AdvanceEPD();
 
-                    const temp = SCAReturnString.alloc(length);
-                    repmovsd_epd(temp.values, scf.FuncReturnTableEPD + epd, length); // 문자열 값을 (4 * length)bytes 만큼 복사한다.
-                    this.strBuffer.appendf("\"{:t}\"", temp.values);
+                    const str = SCAReturnString.alloc(length);
+                    repmovsd_epd(str.values, scf.FuncReturnTableEPD + epd, length); // 값을 (4 * length)bytes 만큼 복사한다.
 
                     foreach(_: EUDLoopRange(length)){
                         AdvanceEPD();
                     }
-                    DoActions(SetMemoryEPD(values, SetTo, temp), SetMemoryEPD(types, SetTo, 2));
+                    DoActions(SetMemoryEPD(values, SetTo, str), SetMemoryEPD(types, SetTo, 2));
                     break;
                 }
                 case 3: { //Array = 3
@@ -157,20 +140,15 @@ object SCAReturn {
                     const length = maskread_epd(scf.FuncReturnTableEPD + epd, ArrayMask); // 배열 길이, 최대 1000 (0 ~ 1023)
                     AdvanceEPD();
 
-                    const temp_main = SCAReturnArray.alloc(length);
-                    this.strBuffer.appendf("[");
+                    const arr = SCAReturnArray.alloc(length);
                     foreach(ai: EUDLoopRange(length)) {
-                        const temp_values, temp_types = temp_main.values + ai, temp_main.types + ai;
-                        if (ai > 0) {
-                            this.strBuffer.appendf(", ");
-                        }
+                        const arr_values, arr_types = arr.values + ai, arr.types + ai;
                         epdswitch(scf.FuncReturnTableEPD + epd, mersenne_gte(3)){  // 변수 종류, 최대 3
                             case 1: { //Number = 1
                                 AdvanceEPD();
 
-                                const temp = dwread_epd(scf.FuncReturnTableEPD + epd);
-                                DoActions(SetMemoryEPD(temp_values, SetTo, temp), SetMemoryEPD(temp_types, SetTo, 1));
-                                this.strBuffer.appendf("{}", temp);
+                                repmovsd_epd(arr_values, scf.FuncReturnTableEPD + epd, 1); // 값을 (4 * 1)bytes 만큼 복사한다.
+                                SetMemoryEPD(arr_types, SetTo, 1);
                                 AdvanceEPD();
                                 break; 
                             }
@@ -180,14 +158,13 @@ object SCAReturn {
                                 const length = maskread_epd(scf.FuncReturnTableEPD + epd, ArrayMask); // 문자열 길이, 최대 1000 (0 ~ 1023)
                                 AdvanceEPD();
 
-                                const temp_sub = SCAReturnString.alloc(length);
-                                repmovsd_epd(temp_sub.values, scf.FuncReturnTableEPD + epd, length); // 문자열 값을 (4 * length)bytes 만큼 복사한다.
-                                this.strBuffer.appendf("\"{:t}\"", temp_sub.values);
+                                const str = SCAReturnString.alloc(length);
+                                repmovsd_epd(str.values, scf.FuncReturnTableEPD + epd, length); // 값을 (4 * length)bytes 만큼 복사한다.
 
                                 foreach(_: EUDLoopRange(length)){
                                     AdvanceEPD();
                                 }
-                                DoActions(SetMemoryEPD(temp_values, SetTo, temp_sub), SetMemoryEPD(temp_types, SetTo, 2));
+                                DoActions(SetMemoryEPD(arr_values, SetTo, str), SetMemoryEPD(arr_types, SetTo, 2));
                                 break;
                             }
                             case 3: { //Array = 3
@@ -201,8 +178,7 @@ object SCAReturn {
                             }
                         }
                     }
-                    this.strBuffer.append("]");
-                    DoActions(SetMemoryEPD(values, SetTo, temp_main), SetMemoryEPD(types, SetTo, 3));
+                    DoActions(SetMemoryEPD(values, SetTo, arr), SetMemoryEPD(types, SetTo, 3));
                     break;
                 }
                 default: {
@@ -211,29 +187,72 @@ object SCAReturn {
                 }
             }
         }
-        this.strBuffer.append("]");
         this.lastepd = epd;
     }
 
     function destructor() {
         foreach(i: EUDLoopRange(this.returncount)){
             const values, types = this.values + i, this.types + i;
-            const temp = dwread_epd(values);
             epdswitch(types, mersenne_gte(3)) {
                 case 2: {
-                    SCAReturnString.free(temp);
+                    SCAReturnString.free(dwread_epd(values));
                     break;
                 }
                 case 3: {
-                    SCAReturnArray.free(temp);
+                    SCAReturnArray.free(dwread_epd(values));
                     break;
                 }
             }
             DoActions(SetMemoryEPD(values, SetTo, 0), SetMemoryEPD(types, SetTo, 0));
         }
-        MiniArrayFree(2);
-        this.strBuffer.insert(0);
-        StrFree();
+        MiniArrayFree(this.values);
+        MiniArrayFree(this.types);
+    }
+
+    function fmt(buffer: StringBuffer): StringBuffer {
+        buffer.insert(0, "[");
+        foreach(i: EUDLoopRange(this.returncount)){
+            const values, types = this.values + i, this.types + i;
+            if (i > 0) {
+                buffer.append(", ");
+            }
+            epdswitch(types, mersenne_gte(3)){ // 변수 종류, 최대 3
+                case 1: { //Number = 1
+                    buffer.appendf("{}", dwread_epd(values));
+                    break;
+                }
+                case 2: { //String = 2
+                    const str = SCAReturnString.cast(dwread_epd(values));
+                    buffer.appendf("\"{:t}\"", str.values);
+                    break;
+                }
+                case 3: { //Array = 3
+                    const arr = SCAReturnArray.cast(dwread_epd(values));
+                    buffer.appendf("[");
+                    foreach(ai: EUDLoopRange(arr.length)) {
+                        const arr_values, arr_types = arr.values + ai, arr.types + ai;
+                        if (ai > 0) {
+                            buffer.appendf(", ");
+                        }
+                        epdswitch(arr_types, mersenne_gte(3)){  // 변수 종류, 최대 3
+                            case 1: { //Number = 1
+                                buffer.appendf("{}", dwread_epd(arr_values));
+                                break; 
+                            }
+                            case 2: { //String = 2
+                                const str = SCAReturnString.cast(dwread_epd(arr_values));
+                                buffer.appendf("\"{:t}\"", str.values);
+                                break;
+                            }
+                        }
+                    }
+                    buffer.append("]");
+                    break;
+                }
+            }
+        }
+        buffer.append("]");
+        return buffer;
     }
 };
 

--- a/EUD Editor 3/Data/TriggerEditor/SCATool.eps
+++ b/EUD Editor 3/Data/TriggerEditor/SCATool.eps
@@ -29,17 +29,18 @@ function Init(){
 	EUDRegisterObjectToNamespace("MSQCValue", MSQCValue);
 	EUDRegisterObjectToNamespace("MSQCBuffer", MSQCBuffer);
 
-	dwwrite_epd(EPD(mappath) + 0, 3722075717);
-	dwwrite_epd(EPD(mappath) + 1, 3982906636);
-	dwwrite_epd(EPD(mappath) + 2, 1185060405);
-	dwwrite_epd(EPD(mappath) + 3, 2930803196);
-	dwwrite_epd(EPD(mappath) + 4, 773278115);
-	dwwrite_epd(EPD(mappath) + 5, 3579781808);
-	dwwrite_epd(EPD(mappath) + 6, 3074824624);
-    dwwrite_epd(EPD(mappath) + 7, 3414833178);
-
-    dwwrite_epd(EPD(mappath) + 8, 0xFFFFFFFF);
-    dwwrite_epd(EPD(mappath) + 9, 0x00000007);
+    DoActions(
+        SetMemoryEPD(EPD(mappath) + 0, SetTo, 3722075717),
+        SetMemoryEPD(EPD(mappath) + 1, SetTo, 3982906636),
+        SetMemoryEPD(EPD(mappath) + 2, SetTo, 1185060405),
+        SetMemoryEPD(EPD(mappath) + 3, SetTo, 2930803196),
+        SetMemoryEPD(EPD(mappath) + 4, SetTo, 773278115),
+        SetMemoryEPD(EPD(mappath) + 5, SetTo, 3579781808),
+        SetMemoryEPD(EPD(mappath) + 6, SetTo, 3074824624),
+        SetMemoryEPD(EPD(mappath) + 7, SetTo, 3414833178),
+        SetMemoryEPD(EPD(mappath) + 8, SetTo, 0xFFFFFFFF),
+        SetMemoryEPD(EPD(mappath) + 9, SetTo, 0x00000007),
+    );
     //0~39
 
     f_repmovsd_epd(EPD(mappath) + 10, EPD(0x57EEE8) + 9 * getuserplayerid(), 7);

--- a/EUD Editor 3/Data/TriggerEditor/SCArchive.eps
+++ b/EUD Editor 3/Data/TriggerEditor/SCArchive.eps
@@ -31,7 +31,7 @@ function Init(){
 
 
 function Exec(){
-	scf.Exec();
+	// scf.Exec(); Unnecessary Exec(), d/t PluginVariable::EUDOnStart(Reg)
 	sct.Exec();
 	scs.Exec();
 	


### PR DESCRIPTION
Arrayalloc 및 MiniArrayalloc이 이미 할당된 arr을 참조하는 버그 수정
SCR obj에 strbuffer 할당하는 대신 fmt 메소드 추가
sca.lua의 불필요한 EPD제거