### PR TITLE
Add English translations to all .lua files in Data/Lua/TriggerEditor

### DIFF
--- a/EUD Editor 3/Data/Lua/TriggerEditor/BGMPlayer.lua
+++ b/EUD Editor 3/Data/Lua/TriggerEditor/BGMPlayer.lua
@@ -9,7 +9,7 @@ BGM
 
 @Language.en-US
 @Summary
-해당플레이어의 BGM을 [BGMName]로 설정합니다.
+Sets the player's BGM to [BGMName].
 @Group
 BGM
 @param.BGMName.BGM
@@ -36,7 +36,7 @@ BGM
 
 @Language.en-US
 @Summary
-해당플레이어의 BGM을 재생합니다.
+Plays the player's BGM.
 @Group
 BGM
 ]================================]
@@ -56,7 +56,7 @@ BGM
 
 @Language.en-US
 @Summary
-해당플레이어의 BGM을 멈춥니다.
+Stops the player's BGM.
 @Group
 BGM
 ]================================]
@@ -76,7 +76,7 @@ BGM
 
 @Language.en-US
 @Summary
-해당플레이어의 BGM을 재개니다.
+Resumes the player's BGM.
 @Group
 BGM
 ]================================]
@@ -96,7 +96,7 @@ BGM
 
 @Language.en-US
 @Summary
-해당플레이어의 BGM을 일시정지입니다.
+Pauses the player's BGM.
 @Group
 BGM
 ]================================]

--- a/EUD Editor 3/Data/Lua/TriggerEditor/CUnit.lua
+++ b/EUD Editor 3/Data/Lua/TriggerEditor/CUnit.lua
@@ -8,9 +8,9 @@
 
 @Language.en-US
 @Summary
-다음에 생성될 유닛의 주소를 반환합니다
+Returns the PTR of the next unit to be created.
 @Group
-구조오프셋
+CUnit Offset
 ]================================]
 function ReadNextUnitPtr()
     echo("cunitread_epd(EPD(0x628438))")
@@ -26,9 +26,9 @@ end
 
 @Language.en-US
 @Summary
-다음에 생성될 유닛의 EPD를 반환합니다
+Returns the EPD of the next unit to be created.
 @Group
-구조오프셋
+CUnit Offset
 ]================================]
 function ReadNextUnitEpd()
     echo("cunitepdread_epd(EPD(0x628438))[[1]]")
@@ -44,9 +44,9 @@ end
 
 @Language.en-US
 @Summary
-다음에 생성될 유닛을 ptr, epd로 반환합니다.
+Returns the PTR and EPD of the next unit to be created.
 @Group
-구조오프셋
+CUnit Offset
 ]================================]
 function ReadNextUnitPtrEpd()
     echo("cunitepdread_epd(EPD(0x628438))")
@@ -64,11 +64,11 @@ ptr이 저장될 변수입니다.
 
 @Language.en-US
 @Summary
-[ptr]에 다음에 생성될 유닛의 주소를 반환합니다
+Stores the PTR of the next unit to be created into [ptr].
 @Group
-구조오프셋
+CUnit Offset
 @param.ptr.Variable
-ptr이 저장될 변수입니다.
+Variable where the ptr will be stored.
 ]================================]
 function SetNextUnitPtr(ptr)
     echo(ptr .. " = cunitread_epd(EPD(0x628438))")
@@ -86,11 +86,11 @@ epd가 저장될 변수입니다.
 
 @Language.en-US
 @Summary
-[epd]에 다음에 생성될 유닛의 EPD를 반환합니다
+Stores the EPD of the next unit to be created into [epd].
 @Group
-구조오프셋
+CUnit Offset
 @param.epd.Variable
-epd가 저장될 변수입니다.
+Variable where the epd will be stored.
 ]================================]
 function SetNextUnitEpd(epd)
     echo(epd .. " = cunitepdread_epd(EPD(0x628438))[[1]]")
@@ -110,13 +110,13 @@ epd가 저장될 변수입니다.
 
 @Language.en-US
 @Summary
-[ptr]에 다음에 생성될 유닛의 PTR을, [epd]에 EPD를 반환합니다
+Stores the PTR of the next unit to be created into [ptr] and the EPD into [epd].
 @Group
-구조오프셋
+CUnit Offset
 @param.ptr.Variable
-ptr가 저장될 변수입니다.
+Variable where the ptr will be stored.
 @param.epd.Variable
-epd가 저장될 변수입니다.
+Variable where the epd will be stored.
 ]================================]
 function SetNextUnitPtrEpd(ptr, epd)
     echo(ptr .. ", " .. epd .. " = cunitepdread_epd(EPD(0x628438))")
@@ -135,11 +135,11 @@ CUint의 주소의 이름입니다.
 
 @Language.en-US
 @Summary
-Offset의 주소와 크기를 반환합니다.
+Returns address and size of the given Offset.
 @Group
-구조오프셋
+CUnit Offset
 @param.Offset.CUnitOffset
-CUint의 주소의 이름입니다.
+Name of the CUnit field.
 ]================================]
 function GetCUnitOffset(Offset)
 	t = {
@@ -371,13 +371,13 @@ end
 
 @Language.en-US
 @Summary
-[ptr]의 [Offset]을 읽어옵니다.
+Reads [Offset] of [ptr].
 @Group
-구조오프셋
+CUnit Offset
 @param.ptr.Variable
-대상 유닛입니다.
+Target unit.
 @param.Offset.CUnitOffset
-읽어올 항목입니다.
+Field to read.
 ]================================]
 function GetCUnitptr(ptr, Offset)
 	table = GetCUnitOffset(Offset)
@@ -411,13 +411,13 @@ end
 
 @Language.en-US
 @Summary
-[epd]의 [Offset]을 읽어옵니다.
+Reads [Offset] of [epd].
 @Group
-구조오프셋
+CUnit Offset
 @param.epd.Variable
-대상 유닛입니다.
+Target unit.
 @param.Offset.CUnitOffset
-읽어올 항목입니다.
+Field to read.
 ]================================]
 function GetCUnitepd(epd, Offset)
 	table = GetCUnitOffset(Offset)
@@ -456,17 +456,17 @@ end
 
 @Language.en-US
 @Summary
-[ptr]의 [Offset]을 [Value]만큼 [Modifier]합니다.
+Modifies [Offset] of [ptr]: [Modifier] [Value].
 @Group
-구조오프셋
+CUnit Offset
 @param.ptr.Variable
-대상 유닛입니다.
+Target unit.
 @param.Offset.CUnitOffset
-변경할 항목입니다.
+Field to modify.
 @param.Value.Number
-값입니다.
+Value.
 @param.Modifier.TrgModifier
-연산할 방식입니다.
+Operation method.
 ]================================]
 function SetCUnitptr(ptr, Offset, Value, Modifier)
 	Modifier = ParseModifier(Modifier)
@@ -512,17 +512,17 @@ end
 
 @Language.en-US
 @Summary
-[epd]의 [Offset]을 [Value]만큼 [Modifier]합니다.
+Modifies [Offset] of [epd]: [Modifier] [Value].
 @Group
-구조오프셋
+CUnit Offset
 @param.epd.Variable
-대상 유닛입니다.
+Target unit.
 @param.Offset.CUnitOffset
-변경할 항목입니다.
+Field to modify.
 @param.Value.Number
-값입니다.
+Value.
 @param.Modifier.TrgModifier
-연산할 방식입니다.
+Operation method.
 ]================================]
 function SetCUnitepd(epd, Offset, Value, Modifier) --구조오프셋/Variable,CUnitOffset,Number,TrgModifier/[epd]의 [Offset]을 [Value]만큼 [Modifier]합니다.
 	Modifier = ParseModifier(Modifier)
@@ -568,17 +568,17 @@ end
 
 @Language.en-US
 @Summary
-[ptr]의 [Offset]가 [Value] [Comparison]인지 확인합니다.
+Checks if [Offset] of [ptr] is [Comparison] [Value].
 @Group
-구조오프셋
+CUnit Offset
 @param.ptr.Variable
-대상 유닛입니다.
+Target unit.
 @param.Offset.CUnitOffset
-변경할 항목입니다.
+Field to check.
 @param.Value.Number
-값입니다.
+Value.
 @param.Comparison.TrgComparison
-비교 방식입니다.
+Operation method.
 ]================================]
 function CUnitptr(ptr, Offset, Value, Comparison)
 	Comparison = ParseComparison(Comparison)
@@ -624,17 +624,17 @@ end
 
 @Language.en-US
 @Summary
-[epd]의 [Offset]가 [Value] [Comparison]인지 확인합니다.
+Checks if [Offset] of [epd] is [Comparison] [Value].
 @Group
-구조오프셋
+CUnit Offset
 @param.epd.Variable
-대상 유닛입니다.
+Target unit.
 @param.Offset.CUnitOffset
-변경할 항목입니다.
+Field to check.
 @param.Value.Number
-값입니다.
+Value.
 @param.Comparison.TrgComparison
-비교 방식입니다.
+Operation method.
 ]================================]
 function CUnitepd(epd, Offset, Value, Comparison)
 	Comparison = ParseComparison(Comparison)

--- a/EUD Editor 3/Data/Lua/TriggerEditor/CompletedUnitCount.lua
+++ b/EUD Editor 3/Data/Lua/TriggerEditor/CompletedUnitCount.lua
@@ -16,17 +16,17 @@
 
 @Language.en-US
 @Summary
-[Player]의 [Unit]의 완료된 유닛보유수를 [Amount]만큼 [Modifier]합니다.
+Modifies [Player]'s completed count of [Unit] by [Amount] using [Modifier].
 @Group
-유닛보유수
+Unit Count
 @param.Unit.TrgUnit
-대상 유닛입니다. 이 유닛이 필요한 테크가 해금됩니다.
+Target unit. Required tech for this unit will be unlocked.
 @param.Player.TrgPlayer
-대상 플레이어입니다.
+Target player.
 @param.Modifier.TrgModifier
-수식입니다.
+Modifier operation.
 @param.Amount.Number
-대상 플레이어입니다.
+Amount to apply.
 ]================================]
 function SetCompletedUnitCount(Unit, Player, Modifier, Amount)
 	Player = ParsePlayer(Player)
@@ -52,13 +52,13 @@ end
 
 @Language.en-US
 @Summary
-[Player]의 [Unit]의 완료된 유닛보유수를 반환합니다.
+Returns [Player]'s completed count of [Unit].
 @Group
-유닛보유수
+Unit Count
 @param.Unit.TrgUnit
-대상 유닛입니다. 이 유닛이 필요한 테크가 해금됩니다.
+Target unit. Required tech for this unit will be unlocked.
 @param.Player.TrgPlayer
-대상 플레이어입니다.
+Target player.
 ]================================]
 function GetCompletedUnitCount(Unit, Player)
 	Player = ParsePlayer(Player)
@@ -80,9 +80,9 @@ end
 
 @Language.en-US
 @Summary
-[Player]의 [Unit]의 완료된 유닛보유수의 주소를 반환합니다.
+Returns the EPD address of [Player]'s completed count for [Unit].
 @Group
-유닛보유수
+Unit Count
 @param.Unit.TrgUnit
 @param.Player.TrgPlayer
 ]================================]

--- a/EUD Editor 3/Data/Lua/TriggerEditor/Dat.lua
+++ b/EUD Editor 3/Data/Lua/TriggerEditor/Dat.lua
@@ -16,17 +16,17 @@ DatFile
 
 @Language.en-US
 @Summary
-[Index]의 [DatType]의 값이 [Comparison] [Value]인지 판단합니다.
+Checks if [Index]'s [DatType] value is [Comparison] [Value].
 @Group
 DatFile
 @param.DatType.UnitsDat
-비교할 파라미터입니다.
+Parameter to compare.
 @param.Index.TrgUnit
-비교경할 오브젝트입니다.
+Object to compare.
 @param.Value.Number
-값입니다.
+Value.
 @param.Comparison.TrgComparison
-비교 방식입니다.
+Comparison method.
 ]================================]
 function UnitsDat(DatType, Index, Value, Comparison) --DatFile/UnitsDat,TrgUnit,Number,TrgComparison/[Index]의 [DatType]의 값이 [Comparison] [Value]인지 판단합니다.
 	Unit = ParseUnit(Index)
@@ -53,17 +53,17 @@ DatFile
 
 @Language.en-US
 @Summary
-[Index]의 [DatType]의 값이 [Comparison] [Value]인지 판단합니다.
+Checks if [Index]'s [DatType] value is [Comparison] [Value].
 @Group
 DatFile
 @param.DatType.WeaponsDat
-비교할 파라미터입니다.
+Parameter to compare.
 @param.Index.Weapon
-비교경할 오브젝트입니다.
+Object to compare.
 @param.Value.Number
-값입니다.
+Value.
 @param.Comparison.TrgComparison
-비교 방식입니다.
+Comparison method.
 ]================================]
 function WeaponsDat(DatType, Index, Value, Comparison) --DatFile/WeaponsDat,Weapon,Number,TrgComparison/[Index]의 [DatType]의 값이 [Comparison] [Value]인지 판단합니다.
 	Weapon = ParseWeapon(Index)
@@ -90,17 +90,17 @@ DatFile
 
 @Language.en-US
 @Summary
-[Index]의 [DatType]의 값이 [Comparison] [Value]인지 판단합니다.
+Checks if [Index]'s [DatType] value is [Comparison] [Value].
 @Group
 DatFile
 @param.DatType.FlingyDat
-비교할 파라미터입니다.
+Parameter to compare.
 @param.Index.Flingy
-비교경할 오브젝트입니다.
+Object to compare.
 @param.Value.Number
-값입니다.
+Value.
 @param.Comparison.TrgComparison
-비교 방식입니다.
+Comparison method.
 ]================================]
 function FlingyDat(DatType, Index, Value, Comparison) --DatFile/FlingyDat,Flingy,Number,TrgComparison/[Index]의 [DatType]의 값이 [Comparison] [Value]인지 판단합니다.
 	Flingy = ParseFlingy(Index)
@@ -127,17 +127,17 @@ DatFile
 
 @Language.en-US
 @Summary
-[Index]의 [DatType]의 값이 [Comparison] [Value]인지 판단합니다.
+Checks if [Index]'s [DatType] value is [Comparison] [Value].
 @Group
 DatFile
 @param.DatType.SpritesDat
-비교할 파라미터입니다.
+Parameter to compare.
 @param.Index.Sprite
-비교경할 오브젝트입니다.
+Object to compare.
 @param.Value.Number
-값입니다.
+Value.
 @param.Comparison.TrgComparison
-비교 방식입니다.
+Comparison method.
 ]================================]
 function SpritesDat(DatType, Index, Value, Comparison) --DatFile/SpritesDat,Sprite,Number,TrgComparison/[Index]의 [DatType]의 값이 [Comparison] [Value]인지 판단합니다.
 	Sprite = ParseSprites(Index)
@@ -164,17 +164,17 @@ DatFile
 
 @Language.en-US
 @Summary
-[Index]의 [DatType]의 값이 [Comparison] [Value]인지 판단합니다.
+Checks if [Index]'s [DatType] value is [Comparison] [Value].
 @Group
 DatFile
 @param.DatType.ImagesDat
-비교할 파라미터입니다.
+Parameter to compare.
 @param.Index.Image
-비교경할 오브젝트입니다.
+Object to compare.
 @param.Value.Number
-값입니다.
+Value.
 @param.Comparison.TrgComparison
-비교 방식입니다.
+Comparison method.
 ]================================]
 function ImagesDat(DatType, Index, Value, Comparison) --DatFile/ImagesDat,Image,Number,TrgComparison/[Index]의 [DatType]의 값이 [Comparison] [Value]인지 판단합니다.
 	Image = ParseImages(Index)
@@ -201,17 +201,17 @@ DatFile
 
 @Language.en-US
 @Summary
-[Index]의 [DatType]의 값이 [Comparison] [Value]인지 판단합니다.
+Checks if [Index]'s [DatType] value is [Comparison] [Value].
 @Group
 DatFile
 @param.DatType.UpgradesDat
-비교할 파라미터입니다.
+Parameter to compare.
 @param.Index.Upgrade
-비교경할 오브젝트입니다.
+Object to compare.
 @param.Value.Number
-값입니다.
+Value.
 @param.Comparison.TrgComparison
-비교 방식입니다.
+Comparison method.
 ]================================]
 function UpgradesDat(DatType, Index, Value, Comparison) --DatFile/UpgradesDat,Upgrade,Number,TrgComparison/[Index]의 [DatType]의 값이 [Comparison] [Value]인지 판단합니다.
 	Upgrade = ParseUpgrades(Index)
@@ -238,17 +238,17 @@ DatFile
 
 @Language.en-US
 @Summary
-[Index]의 [DatType]의 값이 [Comparison] [Value]인지 판단합니다.
+Checks if [Index]'s [DatType] value is [Comparison] [Value].
 @Group
 DatFile
 @param.DatType.TechdataDat
-비교할 파라미터입니다.
+Parameter to compare.
 @param.Index.Tech
-비교경할 오브젝트입니다.
+Object to compare.
 @param.Value.Number
-값입니다.
+Value.
 @param.Comparison.TrgComparison
-비교 방식입니다.
+Comparison method.
 ]================================]
 function TechdataDat(DatType, Index, Value, Comparison) --DatFile/TechdataDat,Tech,Number,TrgComparison/[Index]의 [DatType]의 값이 [Comparison] [Value]인지 판단합니다.
 	Tech = ParseTechData(Index)
@@ -275,17 +275,17 @@ DatFile
 
 @Language.en-US
 @Summary
-[Index]의 [DatType]의 값이 [Comparison] [Value]인지 판단합니다.
+Checks if [Index]'s [DatType] value is [Comparison] [Value].
 @Group
 DatFile
 @param.DatType.OrdersDat
-비교할 파라미터입니다.
+Parameter to compare.
 @param.Index.Order
-비교경할 오브젝트입니다.
+Object to compare.
 @param.Value.Number
-값입니다.
+Value.
 @param.Comparison.TrgComparison
-비교 방식입니다.
+Comparison method.
 ]================================]
 function OrdersDat(DatType, Index, Value, Comparison) --DatFile/OrdersDat,Order,Number,TrgComparison/[Index]의 [DatType]의 값이 [Comparison] [Value]인지 판단합니다.
 	Order = ParseOrder(Index)

--- a/EUD Editor 3/Data/Lua/TriggerEditor/DatOffset.lua
+++ b/EUD Editor 3/Data/Lua/TriggerEditor/DatOffset.lua
@@ -10,11 +10,11 @@ DatFile
 
 @Language.en-US
 @Summary
-[DatType]의 주소를 반환합니다
+Returns the address of [DatType].
 @Group
 DatFile
 @param.DatType.UnitsDat
-파라미터입니다.
+Parameter.
 ]================================]
 function UnitsDatOffset(DatType)
     str = DatOffset("units", DatType)
@@ -33,11 +33,11 @@ DatFile
 
 @Language.en-US
 @Summary
-[DatType]의 주소를 반환합니다
+Returns the address of [DatType].
 @Group
 DatFile
 @param.DatType.WeaponsDat
-파라미터입니다.
+Parameter.
 ]================================]
 function WeaponsDatOffset(DatType)
     str = DatOffset("weapons", DatType)
@@ -56,11 +56,11 @@ DatFile
 
 @Language.en-US
 @Summary
-[DatType]의 주소를 반환합니다
+Returns the address of [DatType].
 @Group
 DatFile
 @param.DatType.FlingyDat
-파라미터입니다.
+Parameter.
 ]================================]
 function FlingyDatOffset(DatType)
     str = DatOffset("flingy", DatType)
@@ -79,11 +79,11 @@ DatFile
 
 @Language.en-US
 @Summary
-[DatType]의 주소를 반환합니다
+Returns the address of [DatType].
 @Group
 DatFile
 @param.DatType.SpritesDat
-파라미터입니다.
+Parameter.
 ]================================]
 function SpritesDatOffset(DatType)
     str = DatOffset("sprites", DatType)
@@ -102,11 +102,11 @@ DatFile
 
 @Language.en-US
 @Summary
-[DatType]의 주소를 반환합니다
+Returns the address of [DatType].
 @Group
 DatFile
 @param.DatType.ImagesDat
-파라미터입니다.
+Parameter.
 ]================================]
 function ImagesDatOffset(DatType)
     str = DatOffset("images", DatType)
@@ -125,11 +125,11 @@ DatFile
 
 @Language.en-US
 @Summary
-[DatType]의 주소를 반환합니다
+Returns the address of [DatType].
 @Group
 DatFile
 @param.DatType.UpgradesDat
-파라미터입니다.
+Parameter.
 ]================================]
 function UpgradesDatOffset(DatType)
     str = DatOffset("upgrades", DatType)
@@ -148,11 +148,11 @@ DatFile
 
 @Language.en-US
 @Summary
-[DatType]의 주소를 반환합니다
+Returns the address of [DatType].
 @Group
 DatFile
 @param.DatType.TechdataDat
-파라미터입니다.
+Parameter.
 ]================================]
 function TechdataDatOffset(DatType)
     str = DatOffset("techdata", DatType)
@@ -171,11 +171,11 @@ DatFile
 
 @Language.en-US
 @Summary
-[DatType]의 주소를 반환합니다
+Returns the address of [DatType].
 @Group
 DatFile
 @param.DatType.OrdersDat
-파라미터입니다.
+Parameter.
 ]================================]
 function OrdersDatOffset(DatType)
     str = DatOffset("orders", DatType)

--- a/EUD Editor 3/Data/Lua/TriggerEditor/EUDTurbo.lua
+++ b/EUD Editor 3/Data/Lua/TriggerEditor/EUDTurbo.lua
@@ -8,9 +8,9 @@ EUDTurbo를 사용합니다.
 
 @Language.en-US
 @Summary
-EUDTurbo를 사용합니다.
+Enables EUDTurbo.
 @Group
-일반
+General
 ]================================]
 function EUDTurbo()
 	echo("dwwrite(0x6509A0, 0)")

--- a/EUD Editor 3/Data/Lua/TriggerEditor/Encoder.lua
+++ b/EUD Editor 3/Data/Lua/TriggerEditor/Encoder.lua
@@ -545,7 +545,7 @@ end
 @Language.en-US
 @Summary
 @Group
-내부함수
+Internal Function
 ]================================]
 function EncodeAllyStatus(s)
     return EncodeConst(AllyStatusDict, s)
@@ -561,7 +561,7 @@ end
 @Language.en-US
 @Summary
 @Group
-내부함수
+Internal Function
 ]================================]
 function EncodeComparison(s)
     return EncodeConst(ComparisonDict, s)
@@ -577,7 +577,7 @@ end
 @Language.en-US
 @Summary
 @Group
-내부함수
+Internal Function
 ]================================]
 function EncodeModifier(s)
     return EncodeConst(ModifierDict, s)
@@ -593,7 +593,7 @@ end
 @Language.en-US
 @Summary
 @Group
-내부함수
+Internal Function
 ]================================]
 function EncodeOrder(s)
     return EncodeConst(OrderDict, s)
@@ -610,7 +610,7 @@ LuaPlayerVariable = "getcurpl()"
 @Language.en-US
 @Summary
 @Group
-내부함수
+Internal Function
 ]================================]
 function EncodePlayer(s)
     if s == CurrentPlayer then
@@ -630,7 +630,7 @@ end
 @Language.en-US
 @Summary
 @Group
-내부함수
+Internal Function
 ]================================]
 function EncodePropState(s)
     return EncodeConst(PropStateDict, s)
@@ -646,7 +646,7 @@ end
 @Language.en-US
 @Summary
 @Group
-내부함수
+Internal Function
 ]================================]
 function EncodeResource(s)
     return EncodeConst(ResourceDict, s)
@@ -662,7 +662,7 @@ end
 @Language.en-US
 @Summary
 @Group
-내부함수
+Internal Function
 ]================================]
 function EncodeScore(s)
     return EncodeConst(ScoreDict, s)
@@ -678,7 +678,7 @@ end
 @Language.en-US
 @Summary
 @Group
-내부함수
+Internal Function
 ]================================]
 function EncodeSwitchAction(s)
     return EncodeConst(SwitchActionDict, s)
@@ -694,7 +694,7 @@ end
 @Language.en-US
 @Summary
 @Group
-내부함수
+Internal Function
 ]================================]
 function EncodeSwitchState(s)
     return EncodeConst(SwitchStateDict, s)
@@ -710,7 +710,7 @@ end
 @Language.en-US
 @Summary
 @Group
-내부함수
+Internal Function
 ]================================]
 function EncodeAIScript(s)
     return EncodeConst(AIScriptDict, s)
@@ -726,7 +726,7 @@ end
 @Language.en-US
 @Summary
 @Group
-내부함수
+Internal Function
 ]================================]
 function EncodeCount(s)
     if s == All then

--- a/EUD Editor 3/Data/Lua/TriggerEditor/GetCounterTimer.lua
+++ b/EUD Editor 3/Data/Lua/TriggerEditor/GetCounterTimer.lua
@@ -8,9 +8,9 @@
 
 @Language.en-US
 @Summary
-현재 카운트 타이머를 반환합니다.
+Returns the current counter timer value.
 @Group
-시스템
+System
 ]================================]
 function GetCounterTime() --일반//현재 카운트 타이머를 반환합니다.
 	echo("dwread(0x58D6F4)")
@@ -26,9 +26,9 @@ end
 
 @Language.en-US
 @Summary
-현재 카운트 타이머 주소를 반환합니다.
+Returns the address of the current counter timer.
 @Group
-시스템
+System
 ]================================]
 function CounterTimeOffset() --일반//현재 카운트 타이머 주소를 반환합니다.
 	echo("0x58D6F4")

--- a/EUD Editor 3/Data/Lua/TriggerEditor/GetDat.lua
+++ b/EUD Editor 3/Data/Lua/TriggerEditor/GetDat.lua
@@ -12,13 +12,13 @@ DatFile
 
 @Language.en-US
 @Summary
-[Index]의 [DatType] 값을 반환합니다.
+Returns the [DatType] value of [Index].
 @Group
 DatFile
 @param.DatType.UnitsDat
-파라미터입니다.
+Parameter.
 @param.Index.TrgUnit
-대상 유닛입니다.
+Target unit.
 ]================================]
 function GetUnitsDat(DatType, Index) --DatFile/UnitsDat,TrgUnit/[Index]의 [DatType] 값을 반환합니다.
 	Unit = ParseUnit(Index)
@@ -40,13 +40,13 @@ DatFile
 
 @Language.en-US
 @Summary
-[Index]의 [DatType] 값을 반환합니다.
+Returns the [DatType] value of [Index].
 @Group
 DatFile
 @param.DatType.WeaponsDat
-파라미터입니다.
+Parameter.
 @param.Index.Weapon
-대상 무기입니다.
+Target weapon.
 ]================================]
 function GetWeaponsDat(DatType, Index) --DatFile/WeaponsDat,Weapon/[Index]의 [DatType] 값을 반환합니다.
 	Weapon = ParseWeapon(Index)
@@ -68,13 +68,13 @@ DatFile
 
 @Language.en-US
 @Summary
-[Index]의 [DatType] 값을 반환합니다.
+Returns the [DatType] value of [Index].
 @Group
 DatFile
 @param.DatType.FlingyDat
-파라미터입니다.
+Parameter.
 @param.Index.Flingy
-대상 비행정보입니다.
+Target flingy.
 ]================================]
 function GetFlingyDat(DatType, Index) --DatFile/FlingyDat,Flingy/[Index]의 [DatType] 값을 반환합니다.
 	Flingy = ParseFlingy(Index)
@@ -96,13 +96,13 @@ DatFile
 
 @Language.en-US
 @Summary
-[Index]의 [DatType] 값을 반환합니다.
+Returns the [DatType] value of [Index].
 @Group
 DatFile
 @param.DatType.SpritesDat
-파라미터입니다.
+Parameter.
 @param.Index.Sprite
-대상 스프라이트입니다.
+Target sprite.
 ]================================]
 function GetSpritesDat(DatType, Index) --DatFile/SpritesDat,Sprite/[Index]의 [DatType] 값을 반환합니다.
 	Sprite = ParseSprites(Index)
@@ -125,13 +125,13 @@ DatFile
 
 @Language.en-US
 @Summary
-[Index]의 [DatType] 값을 반환합니다.
+Returns the [DatType] value of [Index].
 @Group
 DatFile
 @param.DatType.ImagesDat
-파라미터입니다.
+Parameter.
 @param.Index.Image
-대상 이미지입니다.
+Target image.
 ]================================]
 function GetImagesDat(DatType, Index) --DatFile/ImagesDat,Image/[Index]의 [DatType] 값을 반환합니다.
 	Image = ParseImages(Index)
@@ -153,13 +153,13 @@ DatFile
 
 @Language.en-US
 @Summary
-[Index]의 [DatType] 값을 반환합니다.
+Returns the [DatType] value of [Index].
 @Group
 DatFile
 @param.DatType.UpgradesDat
-파라미터입니다.
+Parameter.
 @param.Index.Upgrade
-대상 업그레이드입니다.
+Target upgrade.
 ]================================]
 function GetUpgradesDat(DatType, Index) --DatFile/UpgradesDat,Upgrade/[Index]의 [DatType] 값을 반환합니다.
 	Upgrade = ParseUpgrade(Index)
@@ -181,13 +181,13 @@ DatFile
 
 @Language.en-US
 @Summary
-[Index]의 [DatType] 값을 반환합니다.
+Returns the [DatType] value of [Index].
 @Group
 DatFile
 @param.DatType.TechdataDat
-파라미터입니다.
+Parameter.
 @param.Index.Tech
-대상 기술입니다.
+Target tech.
 ]================================]
 function GetTechdataDat(DatType, Index) --DatFile/TechdataDat,Tech/[Index]의 [DatType] 값을 반환합니다.
 	Tech = ParseTech(Index)
@@ -209,13 +209,13 @@ DatFile
 
 @Language.en-US
 @Summary
-[Index]의 [DatType] 값을 반환합니다.
+Returns the [DatType] value of [Index].
 @Group
 DatFile
 @param.DatType.OrdersDat
-파라미터입니다.
+Parameter.
 @param.Index.Order
-대상 명령입니다.
+Target order.
 ]================================]
 function GetOrdersDat(DatType, Index) --DatFile/OrdersDat,Order/[Index]의 [DatType] 값을 반환합니다.
 	Order = ParseOrder(Index)

--- a/EUD Editor 3/Data/Lua/TriggerEditor/GetDeaths.lua
+++ b/EUD Editor 3/Data/Lua/TriggerEditor/GetDeaths.lua
@@ -12,13 +12,13 @@
 
 @Language.en-US
 @Summary
-[Player]의 [Unit] 데스값을 반환합니다.
+Returns the death count of [Unit] for [Player].
 @Group
-일반
+General
 @param.Unit.TrgUnit
-데스값을 가져올 유닛입니다.
+Unit to get death count for.
 @param.Player.TrgPlayer
-대상 플레이어입니다.
+Target player.
 ]================================]
 function GetDeaths(Unit, Player) -- 일반/TrgUnit,TrgPlayer/[Player]의 [Unit] 데스값을 반환합니다.
     Unit = ParseUnit(Unit)

--- a/EUD Editor 3/Data/Lua/TriggerEditor/GetElapsedTime.lua
+++ b/EUD Editor 3/Data/Lua/TriggerEditor/GetElapsedTime.lua
@@ -8,9 +8,9 @@
 
 @Language.en-US
 @Summary
-게임 진행 시간을 반환합니다.
+Returns the elapsed game time.
 @Group
-시스템
+System
 ]================================]
 function GetElapsedTime() --일반//게임 진행 시간을 반환합니다.
 	echo("dwread(0x58D6F8)")
@@ -26,9 +26,9 @@ end
 
 @Language.en-US
 @Summary
-게임 진행 시간 주소를 반환합니다.
+Returns the address of the elapsed game time.
 @Group
-시스템
+System
 ]================================]
 function ElapsedTimeOffset() --일반//게임 진행 시간 주소를 반환합니다.
 	echo("0x58D6F8")

--- a/EUD Editor 3/Data/Lua/TriggerEditor/Kills.lua
+++ b/EUD Editor 3/Data/Lua/TriggerEditor/Kills.lua
@@ -16,17 +16,17 @@
 
 @Language.en-US
 @Summary
-[Player]가 [Unit]을 죽인 수를 [Amount]만큼 [Modifier]합니다.
+Modifies [Player]'s kill count of [Unit]: [Modifier] [Value].
 @Group
-일반
+General
 @param.Player.TrgPlayer
-대상 플레이어입니다.
+Target player.
 @param.Modifier.TrgModifier
-조절할 방법입니다.
+Adjustment method.
 @param.Amount.Number
-설정할 값입니다.
+Value to apply.
 @param.Unit.TrgUnit
-설정할 유닛입니다.
+Unit to adjust.
 ]================================]
 function SetKills(Player, Modifier, Amount, Unit) --일반/TrgPlayer,TrgModifier,Number,TrgUnit/[Player]의 [Unit]이 죽은 수를 [Amount]만큼 [Modifier]합니다.
 	Player = ParsePlayer(Player)
@@ -52,13 +52,13 @@ end
 
 @Language.en-US
 @Summary
-[Player]가 [Unit]이 죽은 수를 읽습니다.
+Returns [Player]'s kill count of [Unit].
 @Group
-일반
+General
 @param.Unit.TrgUnit
-설정할 유닛입니다.
+Unit to read.
 @param.Player.TrgPlayer
-대상 플레이어입니다.
+Target player.
 ]================================]
 function GetKills(Unit, Player) --일반/TrgUnit,TrgPlayer/[Player]의 [Unit]이 죽은 수를 읽습니다.
 	Player = ParsePlayer(Player)
@@ -82,13 +82,13 @@ end
 
 @Language.en-US
 @Summary
-[Player]가 [Unit]을 죽인 수의 주소를 반환합니다.
+Returns the EPD address of [Player]'s kill count for [Unit].
 @Group
-일반
+General
 @param.Unit.TrgUnit
-설정할 유닛입니다.
+Unit to read.
 @param.Player.TrgPlayer
-대상 플레이어입니다.
+Target player.
 ]================================]
 function KillsEPD(Unit, Player) --일반/TrgUnit,TrgPlayer/[Player]의 [Unit]이 죽은 수의 주소를 반환합니다.
 	Player = ParsePlayer(Player)

--- a/EUD Editor 3/Data/Lua/TriggerEditor/Light.lua
+++ b/EUD Editor 3/Data/Lua/TriggerEditor/Light.lua
@@ -10,9 +10,9 @@
 
 @Language.en-US
 @Summary
-화면 밝기를 [Amount]만큼 [Modifier]합니다.
+Modifies screen brightness: [Modifier] [Amount].
 @Group
-시스템
+System
 @param.Modifier.TrgModifier
 @param.Amount.Number
 ]================================]
@@ -32,9 +32,9 @@ end
 
 @Language.en-US
 @Summary
-화면 밝기의 값을 읽습니다.
+Returns the current screen brightness value.
 @Group
-시스템
+System
 ]================================]
 function GetLight() --일반//화면 밝기의 값을 읽습니다.
     Offset = LightOffset()
@@ -51,9 +51,9 @@ end
 
 @Language.en-US
 @Summary
-화면 밝기의 주소를 반환합니다.
+Returns the address of the screen brightness value.
 @Group
-시스템
+System
 ]================================]
 function LightOffset() --일반//화면 밝기의 주소를 반환합니다.
 	return "0x657A9C"

--- a/EUD Editor 3/Data/Lua/TriggerEditor/Player.lua
+++ b/EUD Editor 3/Data/Lua/TriggerEditor/Player.lua
@@ -11,9 +11,9 @@
 
 @Language.en-US
 @Summary
-[Player]의 아이디를 [ID][Args]로 변경합니다.
+Changes [Player]'s name to [ID][Args].
 @Group
-플레이어
+Player
 @param.Player.TrgPlayer
 @param.ID.FormatString
 @param.Args.Arguments
@@ -41,9 +41,9 @@ end
 
 @Language.en-US
 @Summary
-[Player]의 아이디가 [ID]인지 확인합니다.
+Checks if [Player]'s name is [ID].
 @Group
-플레이어
+Player
 @param.Player.TrgPlayer
 @param.ID.TrgString
 ]================================]

--- a/EUD Editor 3/Data/Lua/TriggerEditor/PlayerAlliances.lua
+++ b/EUD Editor 3/Data/Lua/TriggerEditor/PlayerAlliances.lua
@@ -11,9 +11,9 @@
 
 @Language.en-US
 @Summary
-[Player]이 보는 [DestPlayer]와의 동맹 관계를 [AllyStatus]로 설정합니다.
+Sets [Player]'s alliance status toward [DestPlayer] to [AllyStatus].
 @Group
-동맹
+Alliance
 @param.Player.TrgPlayer
 @param.DestPlayer.TrgPlayer
 @param.AllyStatus.TrgAllyStatus
@@ -58,9 +58,9 @@ end
 
 @Language.en-US
 @Summary
-[Player]이 보는 [DestPlayer]와의 동맹 관계가 [AllyStatus]인지 확인합니다.
+Checks if [Player]'s alliance status toward [DestPlayer] is [AllyStatus].
 @Group
-동맹
+Alliance
 @param.Player.TrgPlayer
 @param.DestPlayer.TrgPlayer
 @param.AllyStatus.TrgAllyStatus
@@ -103,9 +103,9 @@ end
 
 @Language.en-US
 @Summary
-[Player]이 보는 [DestPlayer]와의 동맹 관계를 반환합니다.
+Returns [Player]'s alliance status toward [DestPlayer].
 @Group
-동맹
+Alliance
 @param.Player.TrgPlayer
 @param.DestPlayer.TrgPlayer
 ]================================]
@@ -138,9 +138,9 @@ end
 
 @Language.en-US
 @Summary
-[Player]의 동맹 오프셋을 반환합니다.
+Returns the EPD address of [Player]'s alliance data.
 @Group
-동맹
+Alliance
 @param.Player.TrgPlayer
 ]================================]
 function PlayerAlliancesEPD(Player) --동맹/TrgPlayer/[Player]의 동맹 오프셋을 반환합니다.
@@ -164,9 +164,9 @@ end
 
 @Language.en-US
 @Summary
-[Player]의 동맹 오프셋을 반환합니다.
+Returns the address of [Player]'s alliance data.
 @Group
-동맹
+Alliance
 @param.Player.TrgPlayer
 ]================================]
 function PlayerAlliances(Player) --동맹/TrgPlayer/[Player]의 동맹 오프셋을 반환합니다.

--- a/EUD Editor 3/Data/Lua/TriggerEditor/PlayerSelectedUnit.lua
+++ b/EUD Editor 3/Data/Lua/TriggerEditor/PlayerSelectedUnit.lua
@@ -10,9 +10,9 @@
 
 @Language.en-US
 @Summary
-[Player]의 [Number]번 선택유닛 오프셋을 반환합니다.
+Returns the offset of [Player]'s [Number]th selected unit.
 @Group
-일반
+General
 @param.Player.TrgPlayer
 @param.Number.Number
 ]================================]

--- a/EUD Editor 3/Data/Lua/TriggerEditor/PlayerUnitsAvailable.lua
+++ b/EUD Editor 3/Data/Lua/TriggerEditor/PlayerUnitsAvailable.lua
@@ -11,9 +11,9 @@
 
 @Language.en-US
 @Summary
-[Player]의 [Unit] 유닛 사용 가능 값을 [State]합니다.
+Sets [Player]'s availability state for [Unit] to [State].
 @Group
-플레이어
+Player
 @param.Player.TrgPlayer
 @param.Unit.TrgUnit
 @param.State.TrgSwitchState
@@ -62,9 +62,9 @@ end
 
 @Language.en-US
 @Summary
-[Player]의 [Unit] 유닛 사용 가능 값을 읽어옵니다.
+Returns [Player]'s availability value for [Unit].
 @Group
-플레이어
+Player
 @param.Player.TrgPlayer
 @param.Unit.TrgUnit
 ]================================]
@@ -87,9 +87,9 @@ end
 
 @Language.en-US
 @Summary
-플레이어 유닛 사용 가능 오프셋을 가져옵니다.
+Returns the offset of player unit availability data.
 @Group
-플레이어
+Player
 ]================================]
 function PlayerUnitsAvailableOffset() --일반//플레이어 유닛 사용 가능 오프셋을 가져옵니다.
 	return "0x57F27C"

--- a/EUD Editor 3/Data/Lua/TriggerEditor/Resource.lua
+++ b/EUD Editor 3/Data/Lua/TriggerEditor/Resource.lua
@@ -12,9 +12,9 @@
 
 @Language.en-US
 @Summary
-[Player]의 [ResourceType]을 [Amount]만큼 [Modifier]합니다.
+Modifies [Player]'s [ResourceType]: [Modifier] [Amount].
 @Group
-자원
+Resource
 @param.Player.TrgPlayer
 @param.Modifier.TrgModifier
 @param.Amount.Number
@@ -40,9 +40,9 @@ end
 
 @Language.en-US
 @Summary
-[Player]의 [ResourceType]을 읽습니다.
+Returns [Player]'s [ResourceType] amount.
 @Group
-자원
+Resource
 @param.Player.TrgPlayer
 @param.ResourceType.TrgResource
 ]================================]
@@ -67,9 +67,9 @@ end
 
 @Language.en-US
 @Summary
-[Player]의 [Resource]의 주소를 반환합니다.
+Returns the EPD address of [Player]'s [ResourceType].
 @Group
-자원
+Resource
 @param.Player.TrgPlayer
 @param.ResourceType.TrgResource
 ]================================]

--- a/EUD Editor 3/Data/Lua/TriggerEditor/SCA.lua
+++ b/EUD Editor 3/Data/Lua/TriggerEditor/SCA.lua
@@ -11,13 +11,13 @@ SCA
 
 @Language.en-US
 @Summary
-[ScriptName]을 실행하고 결과를 [ReturnIndex]에 반환합니다.
+Executes [ScriptName] and returns the result to [ReturnIndex].
 @Group
 SCA
 @param.ScriptName.SCAScript
-실행할 스크립트의 이름입니다.
+Name of the script to execute.
 @param.ReturnIndex.Number
-반환할 인덱스입니다.
+Index to return the result to.
 ]================================]
 function SCAScriptRunFunc(ScriptName, ReturnIndex, ...)
 	preDefine("import TriggerEditor.SCALuaWrapper as scalua;")
@@ -51,15 +51,15 @@ SCA
 
 @Language.en-US
 @Summary
-Script 변수 [Variable]에 [Value]만큼 [Modifier]합니다.
+Modifies Script variable [Variable]: [Modifier] [Value].
 @Group
 SCA
 @param.Variable.TrgString
-변수 이름입니다.
+Variable name.
 @param.Value.Number
-넣을 값 입니다.
+Value to apply.
 @param.Modifier.TrgModifier
-연산 종류 입니다.
+Operation type.
 ]================================]
 function SCAScriptWriteVariable(Variable, Modifier, Value)
 	preDefine("import TriggerEditor.SCALuaWrapper as scalua;")
@@ -83,11 +83,11 @@ SCA
 
 @Language.en-US
 @Summary
-Script 변수 [Variable]를 읽습니다.
+Reads Script variable [Variable].
 @Group
 SCA
 @param.Variable.TrgString
-변수 이름입니다.
+Variable name.
 ]================================]
 function SCAScriptReadVariable(Variable)
 	preDefine("import TriggerEditor.SCALuaWrapper as scalua;")
@@ -107,11 +107,11 @@ SCA
 
 @Language.en-US
 @Summary
-Script 변수 [Variable]의 오프셋입니다.
+Returns the offset of Script variable [Variable].
 @Group
 SCA
 @param.Variable.TrgString
-변수 이름입니다.
+Variable name.
 ]================================]
 function SCAScriptVariableOffset(Variable)
 	preDefine("import TriggerEditor.SCALuaWrapper as scalua;")
@@ -131,7 +131,7 @@ SCA
 
 @Language.en-US
 @Summary
-[Slot] 슬롯의 데이터를 불러옵니다.
+Loads data from slot [Slot].
 @Group
 SCA
 @param.Slot.Number
@@ -158,7 +158,7 @@ SCA
 
 @Language.en-US
 @Summary
-[Slot] 슬롯의 데이터를 저장합니다.
+Saves data to slot [Slot].
 @Group
 SCA
 @param.Slot.Number
@@ -185,7 +185,7 @@ SCA
 
 @Language.en-US
 @Summary
-해당플레이어를 [BanType]으로 유즈맵에서 차단합니다.
+Bans the current player from the UMS map with [BanType].
 @Group
 SCA
 @param.BanType.SCABanType
@@ -214,7 +214,7 @@ SCA
 
 @Language.en-US
 @Summary
-시간 정보를 불러옵니다.
+Loads time information.
 @Group
 SCA
 ]================================]
@@ -239,7 +239,7 @@ SCA
 
 @Language.en-US
 @Summary
-글로벌 변수를 불러옵니다.
+Loads global variables.
 @Group
 SCA
 ]================================]
@@ -264,7 +264,7 @@ SCA
 
 @Language.en-US
 @Summary
-시간 정보를 불러옵니다.
+Loads time information once.
 @Group
 SCA
 ]================================]
@@ -289,7 +289,7 @@ SCA
 
 @Language.en-US
 @Summary
-글로벌 변수를 불러옵니다.
+Loads global variables once.
 @Group
 SCA
 ]================================]
@@ -314,7 +314,7 @@ SCA
 
 @Language.en-US
 @Summary
-불러오기 완료를 확인합니다.
+Checks if loading is complete.
 @Group
 SCA
 ]================================]
@@ -336,7 +336,7 @@ SCA
 
 @Language.en-US
 @Summary
-저장 완료를 확인합니다.
+Checks if saving is complete.
 @Group
 SCA
 ]================================]
@@ -358,7 +358,7 @@ SCA
 
 @Language.en-US
 @Summary
-글로벌 변수의 불러오기 완료를 확인합니다.
+Checks if global variable loading is complete.
 @Group
 SCA
 ]================================]
@@ -380,7 +380,7 @@ SCA
 
 @Language.en-US
 @Summary
-시간 정보의 불러오기 완료를 확인합니다.
+Checks if time information loading is complete.
 @Group
 SCA
 ]================================]
@@ -403,7 +403,7 @@ SCA
 
 @Language.en-US
 @Summary
-[Index]번 글로벌 데이터의 값을 반환합니다.
+Returns the value of global data at index [Index].
 @Group
 SCA
 @param.Index.Number
@@ -431,7 +431,7 @@ SCA
 
 @Language.en-US
 @Summary
-[Index]번 글로벌 데이터의 값이 [Comparison] [Value]인지 판단합니다.
+Checks if global data at [Index] is [Comparison] [Value].
 @Group
 SCA
 @param.Index.Number
@@ -477,7 +477,7 @@ SCA
 
 @Language.en-US
 @Summary
-[DateType]을 반환합니다.
+Returns [DateType].
 @Group
 SCA
 @param.DateType.DateType
@@ -521,7 +521,7 @@ SCA
 
 @Language.en-US
 @Summary
-[DateType]이 [Comparison] [Value]인지 판단합니다.
+Checks if [DateType] is [Comparison] [Value].
 @Group
 SCA
 @param.DateType.DateType
@@ -577,7 +577,7 @@ SCA
 
 @Language.en-US
 @Summary
-현재 요일이 [Weekend]인지 확인합니다.
+Checks if the current day is [Weekend].
 @Group
 SCA
 @param.Weekend.Weekend

--- a/EUD Editor 3/Data/Lua/TriggerEditor/Score.lua
+++ b/EUD Editor 3/Data/Lua/TriggerEditor/Score.lua
@@ -12,9 +12,9 @@
 
 @Language.en-US
 @Summary
-[Player]의 [Score]를 [Amount]만큼 [Modifier]합니다.
+Modifies [Player]'s [Score]: [Modifier] [Amount].
 @Group
-스코어
+Score
 @param.Score.EUDScore
 @param.Player.TrgPlayer
 @param.Modifier.TrgModifier
@@ -44,9 +44,9 @@ end
 
 @Language.en-US
 @Summary
-[Player]의 [Score]가 [Comparison] [Amount]인지 확인합니다.
+Checks if [Player]'s [Score] is [Comparison] [Amount].
 @Group
-스코어
+Score
 @param.Score.EUDScore
 @param.Player.TrgPlayer
 @param.Comparison.TrgComparison
@@ -74,9 +74,9 @@ end
 
 @Language.en-US
 @Summary
-[Player]의 [Score] 값을 읽습니다.
+Returns [Player]'s [Score] value.
 @Group
-스코어
+Score
 @param.Score.EUDScore
 @param.Player.TrgPlayer
 ]================================]
@@ -99,9 +99,9 @@ end
 
 @Language.en-US
 @Summary
-[Player]의 [Score] 주소를 반환합니다.
+Returns the EPD address of [Player]'s [Score].
 @Group
-스코어
+Score
 @param.Score.EUDScore
 @param.Player.TrgPlayer
 ]================================]

--- a/EUD Editor 3/Data/Lua/TriggerEditor/Selection.lua
+++ b/EUD Editor 3/Data/Lua/TriggerEditor/Selection.lua
@@ -10,9 +10,9 @@
 
 @Language.en-US
 @Summary
-해당플레이어의 선택 유닛의 버튼셋 ID가 [Comparison] [Amount]인지 확인합니다.
+Checks if the buttonset ID of the locally selected unit is [Comparison] [Amount].
 @Group
-선택인식
+Selection Detection
 @param.Comparison.TrgComparison
 @param.Amount.Number
 
@@ -36,9 +36,9 @@ end
 
 @Language.en-US
 @Summary
-[Player]의 [Score]가 [Comparison] [Amount]인지 확인합니다.
+Checks if the pointer of the locally selected unit is [Comparison] [Amount].
 @Group
-선택인식
+Selection Detection
 @param.Comparison.TrgComparison
 @param.Amount.Number
 ]================================]
@@ -61,9 +61,9 @@ end
 
 @Language.en-US
 @Summary
-[Player]가 [ptr]을 선택했는지 확인합니다.
+Checks if [Player] has selected unit at pointer [ptr].
 @Group
-선택인식
+Selection Detection
 @param.Player.TrgPlayer
 @param.ptr.Number
 ]================================]

--- a/EUD Editor 3/Data/Lua/TriggerEditor/SetDat.lua
+++ b/EUD Editor 3/Data/Lua/TriggerEditor/SetDat.lua
@@ -12,7 +12,7 @@ DatFile
 
 @Language.en-US
 @Summary
-[Index]의 [DatType]의 값을 [Value]로 [Modifier]합니다.
+Modifies the [DatType] value of [Index]: [Modifier] [Value].
 @Group
 DatFile
 @param.DatType.UnitsDat
@@ -41,7 +41,7 @@ DatFile
 
 @Language.en-US
 @Summary
-[Index]의 [DatType]의 값을 [Value]로 [Modifier]합니다.
+Modifies the [DatType] value of [Index]: [Modifier] [Value].
 @Group
 DatFile
 @param.DatType.WeaponsDat
@@ -70,7 +70,7 @@ DatFile
 
 @Language.en-US
 @Summary
-[Index]의 [DatType]의 값을 [Value]로 [Modifier]합니다.
+Modifies the [DatType] value of [Index]: [Modifier] [Value].
 @Group
 DatFile
 @param.DatType.FlingyDat
@@ -99,7 +99,7 @@ DatFile
 
 @Language.en-US
 @Summary
-[Index]의 [DatType]의 값을 [Value]로 [Modifier]합니다.
+Modifies the [DatType] value of [Index]: [Modifier] [Value].
 @Group
 DatFile
 @param.DatType.SpritesDat
@@ -128,7 +128,7 @@ DatFile
 
 @Language.en-US
 @Summary
-[Index]의 [DatType]의 값을 [Value]로 [Modifier]합니다.
+Modifies the [DatType] value of [Index]: [Modifier] [Value].
 @Group
 DatFile
 @param.DatType.ImagesDat
@@ -157,7 +157,7 @@ DatFile
 
 @Language.en-US
 @Summary
-[Index]의 [DatType]의 값을 [Value]로 [Modifier]합니다.
+Modifies the [DatType] value of [Index]: [Modifier] [Value].
 @Group
 DatFile
 @param.DatType.UpgradesDat
@@ -186,7 +186,7 @@ DatFile
 
 @Language.en-US
 @Summary
-[Index]의 [DatType]의 값을 [Value]로 [Modifier]합니다.
+Modifies the [DatType] value of [Index]: [Modifier] [Value].
 @Group
 DatFile
 @param.DatType.TechdataDat
@@ -215,7 +215,7 @@ DatFile
 
 @Language.en-US
 @Summary
-[Index]의 [DatType]의 값을 [Value]로 [Modifier]합니다.
+Modifies the [DatType] value of [Index]: [Modifier] [Value].
 @Group
 DatFile
 @param.DatType.OrdersDat

--- a/EUD Editor 3/Data/Lua/TriggerEditor/Supply.lua
+++ b/EUD Editor 3/Data/Lua/TriggerEditor/Supply.lua
@@ -12,9 +12,9 @@
 
 @Language.en-US
 @Summary
-[Player]의 [SupplyType]를 [Amount]만큼 [Modifier]합니다.
+Modifies [Player]'s [SupplyType]: [Modifier] [Amount].
 @Group
-인구수
+Supply
 @param.SupplyType.SupplyType
 @param.Player.TrgPlayer
 @param.Modifier.TrgModifier
@@ -44,9 +44,9 @@ end
 
 @Language.en-US
 @Summary
-[Player]의 [SupplyType]가 [Comparison] [Amount]인지 확인합니다.
+Checks if [Player]'s [SupplyType] is [Comparison] [Amount].
 @Group
-인구수
+Supply
 @param.SupplyType.SupplyType
 @param.Player.TrgPlayer
 @param.Comparison.TrgComparison
@@ -74,9 +74,9 @@ end
 
 @Language.en-US
 @Summary
-[Player]의 [SupplyType] 값을 읽습니다.
+Returns [Player]'s [SupplyType] value.
 @Group
-인구수
+Supply
 @param.SupplyType.SupplyType
 @param.Player.TrgPlayer
 ]================================]
@@ -99,9 +99,9 @@ end
 
 @Language.en-US
 @Summary
-[Player]의 [SupplyType] 주소를 반환합니다.
+Returns the EPD address of [Player]'s [SupplyType].
 @Group
-인구수
+Supply
 @param.SupplyType.SupplyType
 @param.Player.TrgPlayer
 ]================================]

--- a/EUD Editor 3/Data/Lua/TriggerEditor/Tech.lua
+++ b/EUD Editor 3/Data/Lua/TriggerEditor/Tech.lua
@@ -12,9 +12,9 @@
 
 @Language.en-US
 @Summary
-[Player]의 [Tech]의 현재값을 [Amount]만큼 [Modifier]합니다.
+Modifies the current level of [Tech] for [Player]: [Modifier] [Amount].
 @Group
-테크
+Tech
 @param.Tech.Tech
 @param.Player.TrgPlayer
 @param.Modifier.TrgModifier
@@ -65,9 +65,9 @@ end
 
 @Language.en-US
 @Summary
-[Player]의 [Tech]의 현재값이 [Comparison] [Amount]인지 확인합니다.
+Checks if the current level of [Tech] for [Player] is [Comparison] [Amount].
 @Group
-테크
+Tech
 @param.Tech.Tech
 @param.Player.TrgPlayer
 @param.Comparison.TrgComparison
@@ -111,9 +111,9 @@ end
 
 @Language.en-US
 @Summary
-[Player]의 [Tech]의 현재값을 반환합니다.
+Returns the current level of [Tech] for [Player].
 @Group
-테크
+Tech
 @param.Tech.Tech
 @param.Player.TrgPlayer
 ]================================]
@@ -145,9 +145,9 @@ end
 
 @Language.en-US
 @Summary
-[Player]의 [Tech]의 현재값 주소의 EPD를 반환합니다.
+Returns the EPD address of the current level of [Tech] for [Player].
 @Group
-테크
+Tech
 @param.Tech.Tech
 @param.Player.TrgPlayer
 ]================================]
@@ -186,9 +186,9 @@ end
 
 @Language.en-US
 @Summary
-[Player]의 [Tech]의 현재값 주소를 반환합니다.
+Returns the address of the current level of [Tech] for [Player].
 @Group
-테크
+Tech
 @param.Tech.Tech
 @param.Player.TrgPlayer
 ]================================]
@@ -230,9 +230,9 @@ end
 
 @Language.en-US
 @Summary
-[Player]의 [Tech]의 최대값을 [Amount]만큼 [Modifier]합니다.
+Modifies the maximum level of [Tech] for [Player]: [Modifier] [Amount].
 @Group
-테크
+Tech
 @param.Tech.Tech
 @param.Player.TrgPlayer
 @param.Modifier.TrgModifier
@@ -282,9 +282,9 @@ end
 
 @Language.en-US
 @Summary
-[Player]의 [Tech]의 최대값이 [Comparison] [Amount]인지 확인합니다.
+Checks if the maximum level of [Tech] for [Player] is [Comparison] [Amount].
 @Group
-테크
+Tech
 @param.Tech.Tech
 @param.Player.TrgPlayer
 @param.Comparison.TrgComparison
@@ -328,9 +328,9 @@ end
 
 @Language.en-US
 @Summary
-[Player]의 [Tech]의 최대값을 반환합니다.
+Returns the maximum level of [Tech] for [Player].
 @Group
-테크
+Tech
 @param.Tech.Tech
 @param.Player.TrgPlayer
 ]================================]
@@ -363,9 +363,9 @@ end
 
 @Language.en-US
 @Summary
-[Player]의 [Tech]의 최대값 주소의 EPD를 반환합니다.
+Returns the EPD address of the maximum level of [Tech] for [Player].
 @Group
-테크
+Tech
 @param.Tech.Tech
 @param.Player.TrgPlayer
 ]================================]
@@ -405,9 +405,9 @@ end
 
 @Language.en-US
 @Summary
-[Player]의 [Tech]의 최ㅐ값 주소를 반환합니다.
+Returns the address of the maximum level of [Tech] for [Player].
 @Group
-테크
+Tech
 @param.Tech.Tech
 @param.Player.TrgPlayer
 ]================================]

--- a/EUD Editor 3/Data/Lua/TriggerEditor/TextTool.lua
+++ b/EUD Editor 3/Data/Lua/TriggerEditor/TextTool.lua
@@ -11,9 +11,9 @@
 
 @Language.en-US
 @Summary
-[Text][Args]을 버퍼 [Buffer]를 사용해 출력합니다.
+Prints [Text][Args] using [Buffer].
 @Group
-텍스트출력
+Text Output
 @param.Buffer.TrgString
 @param.Text.FormatString
 @param.Args.Arguments
@@ -44,9 +44,9 @@ end
 
 @Language.en-US
 @Summary
-[Text][Args]을 버퍼 [Buffer]를 사용해 [Line] 라인에 출력합니다.
+Prints [Text][Args] to [Line] using [Buffer].
 @Group
-텍스트출력
+Text Output
 @param.Buffer.TrgString
 @param.Line.Number
 @param.Text.FormatString
@@ -78,9 +78,9 @@ end
 
 @Language.en-US
 @Summary
-[TblID]의 [Offset]위치에 [Text][Args]를 씁니다.
+Writes [Text][Args] at [Offset] position of [TblID].
 @Group
-텍스트출력
+Text Output
 @param.TblID.Tbl
 @param.Offset.Number
 @param.Text.FormatString
@@ -109,9 +109,9 @@ end
 
 @Language.en-US
 @Summary
-[TblID]의 [Offset]위치를 [Text][Args]로 교체합니다.
+Replaces [Offset] position of [TblID] with [Text][Args].
 @Group
-텍스트출력
+Text Output
 @param.TblID.Tbl
 @param.Offset.Number
 @param.Text.FormatString
@@ -138,9 +138,9 @@ end
 
 @Language.en-US
 @Summary
-[Text][Args]을 에러줄에 출력합니다.
+Prints [Text][Args] to the error line.
 @Group
-텍스트출력
+Text Output
 @param.Text.FormatString
 @param.Args.Arguments
 ]================================]

--- a/EUD Editor 3/Data/Lua/TriggerEditor/UnitCount.lua
+++ b/EUD Editor 3/Data/Lua/TriggerEditor/UnitCount.lua
@@ -12,9 +12,9 @@
 
 @Language.en-US
 @Summary
-[Player]의 [Unit]의 유닛보유수를 [Amount]만큼 [Modifier]합니다.
+Modifies [Player]'s count of [Unit] by [Amount] using [Modifier].
 @Group
-유닛보유수
+Unit Count
 @param.Unit.TrgUnit
 @param.Player.TrgPlayer
 @param.Modifier.TrgModifier
@@ -42,9 +42,9 @@ end
 
 @Language.en-US
 @Summary
-[Player]의 [Unit]의 유닛보유수를 반환합니다.
+Returns [Player]'s count of [Unit].
 @Group
-유닛보유수
+Unit Count
 @param.Unit.TrgUnit
 @param.Player.TrgPlayer
 ]================================]
@@ -68,9 +68,9 @@ end
 
 @Language.en-US
 @Summary
-[Player]의 [Unit]의 유닛보유수의 주소를 반환합니다.
+Returns the EPD address of [Player]'s count for [Unit].
 @Group
-유닛보유수
+Unit Count
 @param.Unit.TrgUnit
 @param.Player.TrgPlayer
 ]================================]

--- a/EUD Editor 3/Data/Lua/TriggerEditor/Upgrade.lua
+++ b/EUD Editor 3/Data/Lua/TriggerEditor/Upgrade.lua
@@ -12,9 +12,9 @@
 
 @Language.en-US
 @Summary
-[Player]의 [Upgrade]의 현재값을 [Amount]만큼 [Modifier]합니다.
+Modifies the current level of [Upgrade] for [Player]: [Modifier] [Amount].
 @Group
-업그레이드
+Upgrade
 @param.Upgrade.Upgrade
 @param.Player.TrgPlayer
 @param.Modifier.TrgModifier
@@ -76,9 +76,9 @@ end
 
 @Language.en-US
 @Summary
-[Player]의 [Upgrade]의 현재값이 [Comparison] [Amount]인지 확인합니다.
+Checks if the current level of [Upgrade] for [Player] is [Comparison] [Amount].
 @Group
-업그레이드
+Upgrade
 @param.Upgrade.Upgrade
 @param.Player.TrgPlayer
 @param.Comparison.TrgComparison
@@ -138,9 +138,9 @@ end
 
 @Language.en-US
 @Summary
-[Player]의 [Upgrade]의 현재값을 반환합니다.
+Returns the current level of [Upgrade] for [Player].
 @Group
-업그레이드
+Upgrade
 @param.Upgrade.Upgrade
 @param.Player.TrgPlayer
 ]================================]
@@ -170,9 +170,9 @@ end
 
 @Language.en-US
 @Summary
-[Player]의 [Upgrade]의 현재값 주소를 반환합니다.
+Returns the address of the current level of [Upgrade] for [Player].
 @Group
-업그레이드
+Upgrade
 @param.Upgrade.Upgrade
 @param.Player.TrgPlayer
 ]================================]
@@ -214,9 +214,9 @@ end
 
 @Language.en-US
 @Summary
-[Player]의 [Upgrade]의 최대값을 [Amount]만큼 [Modifier]합니다.
+Modifies the maximum level of [Upgrade] for [Player]: [Modifier] [Amount].
 @Group
-업그레이드
+Upgrade
 @param.Upgrade.Upgrade
 @param.Player.TrgPlayer
 @param.Modifier.TrgModifier
@@ -278,9 +278,9 @@ end
 
 @Language.en-US
 @Summary
-[Player]의 [Upgrade]의 최대값이 [Comparison] [Amount]인지 확인합니다.
+Checks if the maximum level of [Upgrade] for [Player] is [Comparison] [Amount].
 @Group
-업그레이드
+Upgrade
 @param.Upgrade.Upgrade
 @param.Player.TrgPlayer
 @param.Comparison.TrgComparison
@@ -340,9 +340,9 @@ end
 
 @Language.en-US
 @Summary
-[Player]의 [Upgrade]의 최대값을 반환합니다.
+Returns the maximum level of [Upgrade] for [Player].
 @Group
-업그레이드
+Upgrade
 @param.Upgrade.Upgrade
 @param.Player.TrgPlayer
 ]================================]
@@ -372,9 +372,9 @@ end
 
 @Language.en-US
 @Summary
-[Player]의 [Upgrade]의 현재값 주소를 반환합니다.
+Returns the address of the maximum level of [Upgrade] for [Player].
 @Group
-업그레이드
+Upgrade
 @param.Upgrade.Upgrade
 @param.Player.TrgPlayer
 ]================================]

--- a/EUD Editor 3/Data/Lua/TriggerEditor/VariableTool.lua
+++ b/EUD Editor 3/Data/Lua/TriggerEditor/VariableTool.lua
@@ -11,9 +11,9 @@
 
 @Language.en-US
 @Summary
-[Variable]을 [Value]으로 [Modifier]합니다.
+Modifies [Variable]: [Modifier] [Value].
 @Group
-변수
+Variable
 @param.Variable.Variable
 @param.Modifier.TrgModifier
 @param.Value.Number
@@ -56,9 +56,9 @@ end
 
 @Language.en-US
 @Summary
-[Variable]이 [Comparison][Value]인지 판단합니다.
+Checks if [Variable] is [Comparison] [Value].
 @Group
-변수
+Variable
 @param.Variable.Variable
 @param.Comparison.TrgComparison
 @param.Value.Number

--- a/EUD Editor 3/Data/Lua/TriggerEditor/Vision.lua
+++ b/EUD Editor 3/Data/Lua/TriggerEditor/Vision.lua
@@ -11,9 +11,9 @@
 
 @Language.en-US
 @Summary
-[Player]에게 [DestPlayer]의 시야를 [State]합니다.
+Sets [Player]'s vision of [DestPlayer] to [State].
 @Group
-시야
+Vision
 @param.Player.TrgPlayer
 @param.DestPlayer.TrgPlayer
 @param.State.TrgSwitchState
@@ -54,9 +54,9 @@ end
 
 @Language.en-US
 @Summary
-[Player]가 [DestPlayer]를 볼 수 있는지 확인합니다.
+Returns whether [Player] has vision of [DestPlayer].
 @Group
-시야
+Vision
 @param.Player.TrgPlayer
 @param.DestPlayer.TrgPlayer
 ]================================]
@@ -88,9 +88,9 @@ end
 
 @Language.en-US
 @Summary
-[Player]의 시야 오프셋을 반환합니다.
+Returns the EPD address of [Player]'s vision data.
 @Group
-시야
+Vision
 @param.Player.TrgPlayer
 ]================================]
 function VisionEPD(Player) --시야/TrgPlayer/[Player]의 시야 오프셋을 반환합니다.

--- a/EUD Editor 3/Data/Lua/TriggerEditor/Wait.lua
+++ b/EUD Editor 3/Data/Lua/TriggerEditor/Wait.lua
@@ -10,9 +10,9 @@ waittime = 0
 
 @Language.en-US
 @Summary
-프레임 [Time]만큼 기다립니다.
+Waits for [Time] frames.
 @Group
-대기하기
+Wait
 @param.Time.Number
 ]================================]
 function Wait(Time) --대기하기/Number/프레임 [Time]만큼 기다립니다.
@@ -30,9 +30,9 @@ end
 
 @Language.en-US
 @Summary
-대기하기의 시작 부분입니다.
+Starts the wait section.
 @Group
-대기하기
+Wait
 ]================================]
 function WaitStart() --대기하기//대기하기의 시작 부분입니다.
 	waittime = 0
@@ -49,9 +49,9 @@ end
 
 @Language.en-US
 @Summary
-대기하기 조건 부의 시작 부분입니다.
+Starts the wait condition block.
 @Group
-대기하기
+Wait
 ]================================]
 function WaitConditionStart() --대기하기//대기하기 조건 부의 시작 부분입니다.
 	echo("if (WaitTimer == 0 &&")
@@ -67,9 +67,9 @@ end
 
 @Language.en-US
 @Summary
-대기하기 조건 부의 끝 부분입니다.
+Ends the wait condition block.
 @Group
-대기하기
+Wait
 ]================================]
 function WaitConditionEnd() --대기하기//대기하기 조건 부의 끝 부분입니다.
 	echo("){WaitTimer = 1;}")
@@ -85,9 +85,9 @@ end
 
 @Language.en-US
 @Summary
-대기하기 액션 부의 시작 부분입니다.
+Starts the wait action block.
 @Group
-대기하기
+Wait
 ]================================]
 function WaitActionStart() --대기하기//대기하기 액션 부의 시작 부분입니다.
 	echo("if(WaitTimer > 0){if (WaitTimer == 1){")
@@ -103,9 +103,9 @@ end
 
 @Language.en-US
 @Summary
-대기하기 액션 부의 끝 부분입니다.
+Ends the wait action block.
 @Group
-대기하기
+Wait
 ]================================]
 function WaitActionEnd() --대기하기//대기하기 액션 부의 끝 부분입니다.
 	echo("}WaitTimer += 1;")
@@ -121,9 +121,9 @@ end
 
 @Language.en-US
 @Summary
-대기하기의 끝 부분입니다.
+Ends the wait section.
 @Group
-대기하기
+Wait
 ]================================]
 function WaitEnd() --대기하기//대기하기의 끝 부분입니다.
 	echo("if (WaitTimer > " .. waittime .. "){WaitTimer = 0;}}}")

--- a/EUD Editor 3/Data/Lua/TriggerEditor/chatEventTool.lua
+++ b/EUD Editor 3/Data/Lua/TriggerEditor/chatEventTool.lua
@@ -12,13 +12,13 @@
 
 @Language.en-US
 @Summary
-[Player]의 채팅[Chat]을 인식합니다.
+Detects [Player]'s chat message [Chat].
 @Group
-채팅인식
+Chat Detection
 @param.Player.TrgPlayer
-대상 플레이어입니다.
+Target player.
 @param.Chat.TrgString
-인식할 채팅입니다.
+Chat message to detect.
 ]================================]
 function ChatEvent(Player ,Chat)
 	Player = ParsePlayer(Player)
@@ -48,17 +48,17 @@ end
 
 @Language.en-US
 @Summary
-[Player]의 채팅[Start],[Mid],[End]를 인식합니다.
+Detects [Player]'s chat matching [Start], [Mid], [End].
 @Group
-채팅인식
+Chat Detection
 @param.Player.TrgPlayer
-대상 플레이어입니다.
+Target player.
 @param.Start.TrgString
-시작 할 앞부분 입니다. 비어있으면 아무 내용이나 가능합니다.
+Starting text (empty matches any).
 @param.Mid.TrgString
-가운대에 포함될 내용입니다.
+Text to include in the middle.
 @param.End.TrgString
-끝 부분입니다. 비어있으면 아무 내용이나 가능합니다.
+Ending text (empty matches any).
 ]================================]
 function ChatEventPattern(Player ,Start ,Mid ,End)
 	Player = ParsePlayer(Player)

--- a/EUD Editor 3/Data/Lua/TriggerEditor/msqcTool.lua
+++ b/EUD Editor 3/Data/Lua/TriggerEditor/msqcTool.lua
@@ -9,9 +9,9 @@
 
 @Language.en-US
 @Summary
-[Key]를 안전한 문자로 변경합니다.
+Converts [Key] to a safe string.
 @Group
-키인식
+Key Detection
 @param.Key.Key
 ]================================]
 function KeyParse(Key)
@@ -46,11 +46,11 @@ end
 
 @Language.en-US
 @Summary
-[Player]의 키 [Key]가 눌리는 순간을 감지합니다.
+Detects the moment [Player] presses [Key].
 @Group
-키인식
+Key Detection
 @param.Player.TrgPlayer
-대상 플레이어입니다.
+Target player.
 @param.Key.Key
 ]================================]
 function KeyDown(Player, Key)
@@ -76,11 +76,11 @@ end
 
 @Language.en-US
 @Summary
-[Player]의 키 [Key]가 놓는 순간을 감지합니다.
+Detects the moment [Player] releases [Key].
 @Group
-키인식
+Key Detection
 @param.Player.TrgPlayer
-대상 플레이어입니다.
+Target player.
 @param.Key.Key
 ]================================]
 function KeyUp(Player, Key)
@@ -106,11 +106,11 @@ end
 
 @Language.en-US
 @Summary
-[Player]의 키 [Key]를 누르고 있는지 감지합니다.
+Detects if [Player] is holding [Key].
 @Group
-키인식
+Key Detection
 @param.Player.TrgPlayer
-대상 플레이어입니다.
+Target player.
 @param.Key.Key
 ]================================]
 function KeyPress(Player, Key)
@@ -135,11 +135,11 @@ end
 
 @Language.en-US
 @Summary
-[Player]의 마우스 [Button]가 눌리는 순간을 감지합니다.
+Detects the moment [Player] presses mouse [Button].
 @Group
-마우스
+Mouse Detection
 @param.Player.TrgPlayer
-대상 플레이어입니다.
+Target player.
 @param.Button.Button
 ]================================]
 function MouseDown(Player, Button)
@@ -165,11 +165,11 @@ end
 
 @Language.en-US
 @Summary
-[Player]의 마우스 [Button]를 놓는 순간을 감지합니다.
+Detects the moment [Player] releases mouse [Button].
 @Group
-마우스
+Mouse Detection
 @param.Player.TrgPlayer
-대상 플레이어입니다.
+Target player.
 @param.Button.Button
 ]================================]
 function MouseUp(Player, Button)
@@ -195,11 +195,11 @@ end
 
 @Language.en-US
 @Summary
-[Player]의 마우스 [Button]를 누르고 있는지 감지합니다.
+Detects if [Player] is holding mouse [Button].
 @Group
-마우스
+Mouse Detection
 @param.Player.TrgPlayer
-대상 플레이어입니다.
+Target player.
 @param.Button.Button
 ]================================]
 function MousePress(Player, Button)
@@ -222,9 +222,9 @@ end
 
 @Language.en-US
 @Summary
-마우스가 위치한 텍스트의 줄을 반환합니다.
+Returns the line number under the mouse cursor in text.
 @Group
-마우스
+Mouse Detection
 ]================================]
 function LocalMouseLine()
 	echo("((dwread_epd(EPD(0x6CDDC8)) - 94) / 16)")
@@ -248,17 +248,17 @@ X좌표 최대 범위입니다.
 
 @Language.en-US
 @Summary
-[Player]의 마우스가 [Line]번째 줄을 X좌표 [MinX] ~ [MaxX]에서 클릭했을 경우를 인식합니다.
+Detects when [Player] clicks [Line] within X range MinX to MaxX.
 @Group
-마우스
+Mouse Detection
 @param.Player.TrgPlayer
-대상 플레이어입니다.
+Target player.
 @param.Line.Number
-라인입니다. 1 ~ 11이 유효합니다.
+Line number. Valid range is 1 to 11.
 @param.MinX.Number
-X좌표 최소 범위입니다.
+Minimum X coordinate.
 @param.MaxX.Number
-X좌표 최대 범위입니다.
+Maximum X coordinate.
 ]================================]
 function MouseClickLine(Player, Line, MinX, MaxX)
 	Player = ParsePlayer(Player)


### PR DESCRIPTION
Translated **Summary**, **Group** and **param** descriptions in all .lua files, translation might not be perfect

<img width="700" height="450" alt="image" src="https://github.com/user-attachments/assets/131b5dd9-b519-4338-88a3-d9ce9828d0f2" />

<img width="701" height="450" alt="image" src="https://github.com/user-attachments/assets/4171f4f3-a611-4078-aeba-94ff121c1a38" />
